### PR TITLE
Removing file.close() statements

### DIFF
--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -23,6 +23,7 @@ def test_init_database():
     processor.init_database(filename, datapath)
 
     # remove file
+    processor.close()
     os.remove(filename)
 
     # checks if arrays were saved to file and read back correctly
@@ -45,15 +46,44 @@ def test_data_slice():
     create_file(filename, datapath, labels, live, timestamps, spectra)
 
     processor = ds.DataSet(labels)
+    # load file into processor's "memory"
+    processor.init_database(filename, datapath)
 
     # query 3 random rows in the fake spectra matrix
     rows = np.random.choice(range(10), 3, replace = False)
     # sorted() for correct index syntax
     real_slice = spectra[sorted(rows)]
-    test_slice = processor.data_slice(filename, datapath, sorted(rows))
+    test_slice = processor.data_slice(datapath, sorted(rows))
 
     # remove file
+    processor.close()
     os.remove(filename)
 
     # check the entire array for approximately equal
     np.testing.assert_almost_equal(test_slice, real_slice, decimal = 5)
+
+def test_close():
+    # Creating sample dataset
+    filename = 'testfile.h5'
+    datapath = '/uppergroup/lowergroup/'
+    labels = {'live': '2x4x16LiveTimes',
+              'timestamps': '2x4x16Times',
+              'spectra': '2x4x16Spectra'}
+
+    # randomized data to store (smaller than an actual MUSE file)
+    live = np.random.rand(1000,)
+    timestamps = np.random.rand(1000,)
+    spectra = np.random.rand(10,1000)
+
+    create_file(filename, datapath, labels, live, timestamps, spectra)
+
+    processor = ds.DataSet(labels)
+    # load file into processor's "memory"
+    processor.init_database(filename, datapath)
+
+    processor.close()
+    # fails if file was not closed
+    # therefore processor.file = True because it is still a file
+    assert not processor.file
+
+    os.remove(filename)


### PR DESCRIPTION
Resolves #3. This PR removes the `file.close()` statements from `DataSet` methods. This is important because, as-is, `DataSet` closes the file it is reading _every time_ it slices data. This could be costly when doing a lot of data slicing as the numerous data i/o actions slows a script down. Instead, the file remains open as an attribute of `DataSet` unless `DataSet.close()` is called. A nice "unintended" consequence of this change is that the file name is [no longer needed when slicing data](https://github.com/stompsjo/RadClass/blob/9ddb3d72b1fab664e9190481c023efc45a519270/RadClass/DataSet.py#L85).

A new test (`test_close()`) has been included to ensure the method is functional, although I'm not sure how necessary it is?

There is some [interesting](https://stackoverflow.com/questions/865115/how-do-i-correctly-clean-up-a-python-object) [discussion](https://stackoverflow.com/questions/8582076/class-wrapper-around-file-proper-way-to-close-file-handle-when-no-longer-refe) about using a `.close()` method instead of a `__enter__` and `__exit__` combination. As mentioned in this Stack Overflow pages, I think a `.close()` method is appropriate here since `DataSet.file` should never be called outside of `DataSet` and therefore will be closed no matter what when `DataSet` is closed. Instead, the purpose of `.close()` is to provide parent classes a way of "recycling" a child `DataSet` object to analyze several data files and should be completely optional. This seems like an appropriate workflow for this project.