### PR TITLE
BackgroundEstimator Analysis Parameter Class

### DIFF
--- a/RadClass/BackgroundEstimator.py
+++ b/RadClass/BackgroundEstimator.py
@@ -16,7 +16,6 @@ class BackgroundEstimator:
     confidence: Percentage of samples to disregard. 1-confidence number of
         samples are saved. For example, if confidence=0.95, the lowest 5% of
         count rates/timestamps are saved.
-    store_all: Boolean. Indicates whether to store spectral information.
     spectra: Optional NumPy array that stores spectral data from energy bins.
     energy_bins: The number of energy bins defined by the data under analysis.
     '''
@@ -24,31 +23,8 @@ class BackgroundEstimator:
     background = pd.DataFrame(columns=['timestamp', 'count_rate'])
     data = np.empty((0, 2))
 
-    def __init__(self, confidence=0.95,
-                 store_all=False, energy_bins=1000):
+    def __init__(self, confidence=0.95):
         self.confidence = confidence
-        self.energy_bins = energy_bins
-
-        self.store_all = store_all
-        if store_all:
-            self.store_all = store_all
-            self.spectra = np.empty((0, energy_bins))
-
-    '''
-    def __del__(self):
-        self.background = pd.DataFrame(columns=['timestamp', 'count_rate'])
-        self.estimate()
-        # this method could be compressed to save memory
-        self.background.to_csv(self.ofilename+'.csv', index=False)
-    '''
-
-    def save_all(self):
-        '''
-        Adds spectra to saved data if requested.
-        '''
-
-        for i in range(self.energy_bins):
-            self.background[str(i+1)] = self.spectra[:, i]
 
     def sort(self):
         '''
@@ -62,18 +38,16 @@ class BackgroundEstimator:
         '''
         Saves data to a Pandas DataFrame and selects a subset with the smallest
             gross count rates.
+        If not writing to file, this must be called manually to prune samples.
 
         Attributes:
         samples_size: The total number of samples analyzed.
         num_samples: The number of samples to select and save.
         '''
+
         # building pandas DataFrame once from numpy array
         self.background['timestamp'] = self.data[:, 0]
         self.background['count_rate'] = self.data[:, 1]
-
-        # must happen before estimation to maintain order of rows
-        if self.store_all:
-            self.save_all()
 
         # find number of background samples
         sample_size = len(self.background.index)
@@ -95,32 +69,19 @@ class BackgroundEstimator:
 
         count_rate = np.sum(data)
 
-        if self.store_all:
-            self.spectra = np.vstack((self.spectra, data))
-
-        # alternative: use pandas and "append"
-        # slower (by 3 and 20 minutes respectively) than storing in array
-        # dfrow = {'timestamp': timestamp, 'count-rate': count_rate}
-        # self.background.loc[len(self.background.index)] = dfrow
-        # self.background = pd.concat([self.background,
-        #                              pd.DataFrame([data],
-        #                                           index=[timestamp])])
-
         # using numpy to build lightweight matrix instead of pandas
         self.data = np.vstack([self.data, [timestamp, count_rate]])
 
-        # instead of estimating at the end, checkpointing could occur
-        # if len(self.data) % 10000:
-        #    self.estimate()
-
     def write(self, ofilename='bckg_results'):
         '''
-        Identical to destructor but can be manually called.
-        NOTE: Only write or __del__ should be kept, but there is a design
-            question of which is the appropriate method to write to file.
+        Writes results to file.
+        Calls estimate() first to prune data array, only saving
+            (1-confidence)% of samples.
+
+        Attributes:
+        ofilename: string, exluding file extension, for filename to save.
         '''
 
-        # user must call estimate, or it could be part of write()
-        # self.estimate()
-        # this method could be compressed to save memory
+        # until estimate() is called, all background count-rates are saved
+        self.estimate()
         self.background.to_csv(ofilename+'.csv', index=False)

--- a/RadClass/BackgroundEstimator.py
+++ b/RadClass/BackgroundEstimator.py
@@ -41,22 +41,19 @@ class BackgroundEstimator:
         If not writing to file, this must be called manually to prune samples.
 
         Attributes:
-        samples_size: The total number of samples analyzed.
-        num_samples: The number of samples to select and save.
+        cutoff: count-rate value for the percentile of samples
         '''
+
+        # find number of background samples
+        cutoff = np.percentile(self.data[:, 1], (1-self.confidence)*100)
+        self.data = self.data[self.data[:, 1] < cutoff]
 
         # building pandas DataFrame once from numpy array
         self.background['timestamp'] = self.data[:, 0]
         self.background['count_rate'] = self.data[:, 1]
 
-        # find number of background samples
-        sample_size = len(self.background.index)
-        # +1 to account for indexing
-        num_samples = math.floor(sample_size * (1-self.confidence)) + 1
-
-        # sort and separate the smallest count-rates
+        # sort for convenience the smallest count-rates
         self.background = self.sort()
-        self.background = self.background.iloc[:num_samples]
 
     def run(self, data, timestamp):
         '''

--- a/RadClass/BackgroundEstimator.py
+++ b/RadClass/BackgroundEstimator.py
@@ -16,8 +16,6 @@ class BackgroundEstimator:
     confidence: Percentage of samples to disregard. 1-confidence number of
         samples are saved. For example, if confidence=0.95, the lowest 5% of
         count rates/timestamps are saved.
-    ofilename: Output filename excluding extension. File is stored as a csv.
-        Default is bckg_results.
     store_all: Boolean. Indicates whether to store spectral information.
     spectra: Optional NumPy array that stores spectral data from energy bins.
     energy_bins: The number of energy bins defined by the data under analysis.
@@ -26,10 +24,9 @@ class BackgroundEstimator:
     background = pd.DataFrame(columns=['timestamp', 'count_rate'])
     data = np.empty((0, 2))
 
-    def __init__(self, confidence=0.95, ofilename='bckg_results',
+    def __init__(self, confidence=0.95,
                  store_all=False, energy_bins=1000):
         self.confidence = confidence
-        self.ofilename = ofilename
         self.energy_bins = energy_bins
 
         self.store_all = store_all
@@ -37,15 +34,13 @@ class BackgroundEstimator:
             self.store_all = store_all
             self.spectra = np.empty((0, energy_bins))
 
+    '''
     def __del__(self):
-        '''
-        Saves results upon completion of script, even if the script crashes.
-        '''
-
         self.background = pd.DataFrame(columns=['timestamp', 'count_rate'])
         self.estimate()
         # this method could be compressed to save memory
         self.background.to_csv(self.ofilename+'.csv', index=False)
+    '''
 
     def save_all(self):
         '''
@@ -118,13 +113,14 @@ class BackgroundEstimator:
         # if len(self.data) % 10000:
         #    self.estimate()
 
-    def write(self):
+    def write(self, ofilename='bckg_results'):
         '''
         Identical to destructor but can be manually called.
         NOTE: Only write or __del__ should be kept, but there is a design
             question of which is the appropriate method to write to file.
         '''
 
-        self.estimate()
+        # user must call estimate, or it could be part of write()
+        # self.estimate()
         # this method could be compressed to save memory
-        self.background.to_csv(self.ofilename+'.csv', index=False)
+        self.background.to_csv(ofilename+'.csv', index=False)

--- a/RadClass/BackgroundEstimator.py
+++ b/RadClass/BackgroundEstimator.py
@@ -1,0 +1,130 @@
+import numpy as np
+import pandas as pd
+import math
+
+
+class BackgroundEstimator:
+    '''
+    Integrates a gross count rate from a spectrum and orders samples in
+        ascending order of magnitude. Saves a certain percentage samples
+        to file with corresponding gross count rate.
+
+    Attributes:
+    background: Pandas DataFrame used to store timestamps and count rates.
+    data: Numpy array used to incrementally store data throughout analysis
+        before sending/saving in background.
+    confidence: Percentage of samples to disregard. 1-confidence number of
+        samples are saved. For example, if confidence=0.95, the lowest 5% of
+        count rates/timestamps are saved.
+    ofilename: Output filename excluding extension. File is stored as a csv.
+        Default is bckg_results.
+    store_all: Boolean. Indicates whether to store spectral information.
+    spectra: Optional NumPy array that stores spectral data from energy bins.
+    energy_bins: The number of energy bins defined by the data under analysis.
+    '''
+
+    background = pd.DataFrame(columns=['timestamp', 'count_rate'])
+    data = np.empty((0, 2))
+
+    def __init__(self, confidence=0.95, ofilename='bckg_results',
+                 store_all=False, energy_bins=1000):
+        self.confidence = confidence
+        self.ofilename = ofilename
+        self.energy_bins = energy_bins
+
+        self.store_all = store_all
+        if store_all:
+            self.store_all = store_all
+            self.spectra = np.empty((0, energy_bins))
+
+    def __del__(self):
+        '''
+        Saves results upon completion of script, even if the script crashes.
+        '''
+
+        self.background = pd.DataFrame(columns=['timestamp', 'count_rate'])
+        self.estimate()
+        # this method could be compressed to save memory
+        self.background.to_csv(self.ofilename+'.csv', index=False)
+
+    def save_all(self):
+        '''
+        Adds spectra to saved data if requested.
+        '''
+
+        for i in range(self.energy_bins):
+            self.background[str(i+1)] = self.spectra[:, i]
+
+    def sort(self):
+        '''
+        Wrapper function for Pandas DataFrame sort_values method. Organizes
+            samples in ascending order of gross count rate.
+        '''
+
+        return self.background.sort_values(by='count_rate', ascending=True)
+
+    def estimate(self):
+        '''
+        Saves data to a Pandas DataFrame and selects a subset with the smallest
+            gross count rates.
+
+        Attributes:
+        samples_size: The total number of samples analyzed.
+        num_samples: The number of samples to select and save.
+        '''
+        # building pandas DataFrame once from numpy array
+        self.background['timestamp'] = self.data[:, 0]
+        self.background['count_rate'] = self.data[:, 1]
+
+        # must happen before estimation to maintain order of rows
+        if self.store_all:
+            self.save_all()
+
+        # find number of background samples
+        sample_size = len(self.background.index)
+        # +1 to account for indexing
+        num_samples = math.floor(sample_size * (1-self.confidence)) + 1
+
+        # sort and separate the smallest count-rates
+        self.background = self.sort()
+        self.background = self.background.iloc[:num_samples]
+
+    def run(self, data, timestamp):
+        '''
+        Method called by parent class during analysis. Integrates/collects a
+            gross count rate and stores it in an iterim NumPy array.
+
+        Attributes:
+        count_rate: gross count rate from individual observation.
+        '''
+
+        count_rate = np.sum(data)
+
+        if self.store_all:
+            self.spectra = np.vstack((self.spectra, data))
+
+        # alternative: use pandas and "append"
+        # slower (by 3 and 20 minutes respectively) than storing in array
+        # dfrow = {'timestamp': timestamp, 'count-rate': count_rate}
+        # self.background.loc[len(self.background.index)] = dfrow
+        # self.background = pd.concat([self.background,
+        #                              pd.DataFrame([data],
+        #                                           index=[timestamp])])
+
+        # using numpy to build lightweight matrix instead of pandas
+        self.data = np.vstack([self.data, [timestamp, count_rate]])
+
+        # instead of estimating at the end, checkpointing could occur
+        # if len(self.data) % 10000:
+        #    self.estimate()
+
+    def write(self):
+        '''
+        Identical to destructor but can be manually called.
+        NOTE: Only write or __del__ should be kept, but there is a design
+            question of which is the appropriate method to write to file.
+        '''
+
+        self.estimate()
+        # this method could be compressed to save memory
+        self.background.to_csv(self.ofilename+'.csv', index=False)

--- a/tests/test_BackgroundEstimator.py
+++ b/tests/test_BackgroundEstimator.py
@@ -27,15 +27,10 @@ def init_test_file():
 
 def test_init():
     confidence = 0.8
-    store_all = True
 
-    bckg = BackgroundEstimator(confidence=confidence,
-                               store_all=store_all,
-                               energy_bins=test_data.energy_bins)
+    bckg = BackgroundEstimator(confidence=confidence)
 
     np.testing.assert_equal(confidence, bckg.confidence)
-    np.testing.assert_equal(store_all, bckg.store_all)
-    np.testing.assert_equal(test_data.energy_bins, bckg.energy_bins)
 
 
 def test_estimation():
@@ -55,7 +50,9 @@ def test_estimation():
     #   counts * integration / live-time
     expected = (((integration-1)**2 + (integration-1)) /
                 (2*test_data.livetime)) * test_data.energy_bins / integration
-    np.testing.assert_almost_equal(bckg.background.iloc[0][1], expected, decimal=3)
+    np.testing.assert_almost_equal(bckg.background.iloc[0][1],
+                                   expected,
+                                   decimal=3)
 
     time_idx = np.where(spectra == 0)[0][0]
     np.testing.assert_equal(bckg.background.iloc[0][0], timestamps[time_idx])
@@ -65,26 +62,34 @@ def test_estimation():
     np.testing.assert_equal(len(bckg.background), expected_num)
 
 
-def test_spectral_storage():
+def test_write():
     stride = 10
     integration = 10
 
     confidence = 0.8
-    bckg = BackgroundEstimator(confidence=confidence,
-                               store_all=True,
-                               energy_bins=test_data.energy_bins)
+    bckg = BackgroundEstimator(confidence=confidence)
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
                           test_data.filename, store_data=True, analysis=bckg)
     classifier.run_all()
 
-    bckg.estimate()
-    bckg.write()
+    ofilename = 'bckg_test'
+    bckg.write(ofilename=ofilename)
 
-    expected = np.full((test_data.energy_bins,),
-                       ((integration-1)**2 + (integration-1)) /
-                       (2*test_data.livetime*integration))
-    results = np.genfromtxt('bckg_results.csv', delimiter=',', skip_header=1)
-    np.testing.assert_almost_equal(results[0][2:], expected, decimal=3)
+    results = np.genfromtxt(ofilename+'.csv', delimiter=',')[1:]
+    print(results)
 
-    os.remove('bckg_results.csv')
+    # the resulting observation should be:
+    #   counts * integration / live-time
+    expected = (((integration-1)**2 + (integration-1)) /
+                (2*test_data.livetime)) * test_data.energy_bins / integration
+    np.testing.assert_almost_equal(results[0][1], expected, decimal=3)
+
+    time_idx = np.where(spectra == 0)[0][0]
+    np.testing.assert_equal(results[0][0], timestamps[time_idx])
+
+    expected_num = round((test_data.timesteps / integration) *
+                         (1 - confidence))
+    np.testing.assert_equal(results.shape[0], expected_num)
+
+    os.remove(ofilename+'.csv')

--- a/tests/test_BackgroundEstimator.py
+++ b/tests/test_BackgroundEstimator.py
@@ -50,12 +50,12 @@ def test_estimation():
     #   counts * integration / live-time
     expected = (((integration-1)**2 + (integration-1)) /
                 (2*test_data.livetime)) * test_data.energy_bins
-    np.testing.assert_almost_equal(bckg.background.iloc[0][1],
+    np.testing.assert_almost_equal(bckg.background[0][1],
                                    expected,
                                    decimal=3)
 
     time_idx = np.where(spectra == 0)[0][0]
-    np.testing.assert_equal(bckg.background.iloc[0][0], timestamps[time_idx])
+    np.testing.assert_equal(bckg.background[0][0], timestamps[time_idx])
 
     expected_num = round((test_data.timesteps / integration) *
                          (1 - confidence))
@@ -76,7 +76,7 @@ def test_write():
     ofilename = 'bckg_test'
     bckg.write(ofilename=ofilename)
 
-    results = np.genfromtxt(ofilename+'.csv', delimiter=',')[1:]
+    results = np.loadtxt(fname=ofilename+'.csv', delimiter=',')
     print(results)
 
     # the resulting observation should be:

--- a/tests/test_BackgroundEstimator.py
+++ b/tests/test_BackgroundEstimator.py
@@ -1,0 +1,98 @@
+import numpy as np
+import pytest
+import os
+from datetime import datetime, timedelta
+
+from RadClass.RadClass import RadClass
+from RadClass.BackgroundEstimator import BackgroundEstimator
+import tests.test_data as test_data
+
+start_date = datetime(2019, 2, 2)
+delta = timedelta(seconds=1)
+timestamps = np.arange(start_date,
+                       start_date + (test_data.timesteps * delta),
+                       delta).astype('datetime64[s]').astype('float64')
+
+live = np.full((len(timestamps),), test_data.livetime)
+# randomly order incremental "spectra"
+values = np.arange(test_data.timesteps)
+spectra = np.array([np.full((test_data.energy_bins,), x) for x in values])
+
+
+@pytest.fixture(scope="module", autouse=True)
+def init_test_file():
+    # create sample test file with above simulated data
+    yield test_data.create_file(live, timestamps, spectra)
+    os.remove(test_data.filename)
+
+
+def test_init():
+    confidence = 0.8
+    ofilename = 'test_ofilename'
+    store_all = True
+
+    bckg = BackgroundEstimator(confidence=confidence,
+                               ofilename=ofilename,
+                               store_all=store_all,
+                               energy_bins=test_data.energy_bins)
+
+    np.testing.assert_equal(confidence, bckg.confidence)
+    np.testing.assert_equal(ofilename, bckg.ofilename)
+    np.testing.assert_equal(store_all, bckg.store_all)
+    np.testing.assert_equal(test_data.energy_bins, bckg.energy_bins)
+
+
+def test_estimation():
+    stride = 100
+    integration = 100
+
+    confidence = 0.8
+    ofilename = 'bckg_results'
+    bckg = BackgroundEstimator(confidence=confidence, ofilename=ofilename)
+    # run handler script
+    classifier = RadClass(stride, integration, test_data.datapath,
+                          test_data.filename, store_data=True, analysis=bckg)
+    classifier.run_all()
+
+    bckg.write()
+
+    # the resulting observation should be:
+    #   counts * integration / live-time
+    expected = (((integration-1)**2 + (integration-1)) /
+                (2*test_data.livetime)) * test_data.energy_bins
+    results = np.genfromtxt('bckg_results.csv', delimiter=',', skip_header=1)
+    np.testing.assert_almost_equal(results[0][1], expected, decimal=3)
+
+    time_idx = np.where(values == 0)[0][0]
+    np.testing.assert_equal(results[0][0], timestamps[time_idx])
+
+    expected_num = round((test_data.timesteps / integration) *
+                         (1 - confidence))
+    np.testing.assert_equal(len(results), expected_num)
+
+    os.remove('bckg_results.csv')
+
+
+def test_spectral_storage():
+    stride = 100
+    integration = 100
+
+    confidence = 0.8
+    ofilename = 'bckg_results'
+    bckg = BackgroundEstimator(confidence=confidence, ofilename=ofilename,
+                               store_all=True,
+                               energy_bins=test_data.energy_bins)
+    # run handler script
+    classifier = RadClass(stride, integration, test_data.datapath,
+                          test_data.filename, store_data=True, analysis=bckg)
+    classifier.run_all()
+
+    bckg.write()
+
+    expected = np.full((test_data.energy_bins,),
+                       ((integration-1)**2 + (integration-1)) /
+                       (2*test_data.livetime))
+    results = np.genfromtxt('bckg_results.csv', delimiter=',', skip_header=1)
+    np.testing.assert_almost_equal(results[0][2:], expected, decimal=3)
+
+    os.remove('bckg_results.csv')

--- a/tests/test_BackgroundEstimator.py
+++ b/tests/test_BackgroundEstimator.py
@@ -14,9 +14,8 @@ timestamps = np.arange(start_date,
                        delta).astype('datetime64[s]').astype('float64')
 
 live = np.full((len(timestamps),), test_data.livetime)
-# randomly order incremental "spectra"
-values = np.arange(test_data.timesteps)
-spectra = np.array([np.full((test_data.energy_bins,), x) for x in values])
+spectra = np.arange(test_data.timesteps)
+spectra = np.full((test_data.energy_bins, spectra.shape[0]), spectra).T
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -28,58 +27,50 @@ def init_test_file():
 
 def test_init():
     confidence = 0.8
-    ofilename = 'test_ofilename'
     store_all = True
 
     bckg = BackgroundEstimator(confidence=confidence,
-                               ofilename=ofilename,
                                store_all=store_all,
                                energy_bins=test_data.energy_bins)
 
     np.testing.assert_equal(confidence, bckg.confidence)
-    np.testing.assert_equal(ofilename, bckg.ofilename)
     np.testing.assert_equal(store_all, bckg.store_all)
     np.testing.assert_equal(test_data.energy_bins, bckg.energy_bins)
 
 
 def test_estimation():
-    stride = 100
-    integration = 100
+    stride = 10
+    integration = 10
 
     confidence = 0.8
-    ofilename = 'bckg_results'
-    bckg = BackgroundEstimator(confidence=confidence, ofilename=ofilename)
+    bckg = BackgroundEstimator(confidence=confidence)
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
                           test_data.filename, store_data=True, analysis=bckg)
     classifier.run_all()
 
-    bckg.write()
+    bckg.estimate()
 
     # the resulting observation should be:
     #   counts * integration / live-time
     expected = (((integration-1)**2 + (integration-1)) /
-                (2*test_data.livetime)) * test_data.energy_bins
-    results = np.genfromtxt('bckg_results.csv', delimiter=',', skip_header=1)
-    np.testing.assert_almost_equal(results[0][1], expected, decimal=3)
+                (2*test_data.livetime)) * test_data.energy_bins / integration
+    np.testing.assert_almost_equal(bckg.background.iloc[0][1], expected, decimal=3)
 
-    time_idx = np.where(values == 0)[0][0]
-    np.testing.assert_equal(results[0][0], timestamps[time_idx])
+    time_idx = np.where(spectra == 0)[0][0]
+    np.testing.assert_equal(bckg.background.iloc[0][0], timestamps[time_idx])
 
     expected_num = round((test_data.timesteps / integration) *
                          (1 - confidence))
-    np.testing.assert_equal(len(results), expected_num)
-
-    os.remove('bckg_results.csv')
+    np.testing.assert_equal(len(bckg.background), expected_num)
 
 
 def test_spectral_storage():
-    stride = 100
-    integration = 100
+    stride = 10
+    integration = 10
 
     confidence = 0.8
-    ofilename = 'bckg_results'
-    bckg = BackgroundEstimator(confidence=confidence, ofilename=ofilename,
+    bckg = BackgroundEstimator(confidence=confidence,
                                store_all=True,
                                energy_bins=test_data.energy_bins)
     # run handler script
@@ -87,11 +78,12 @@ def test_spectral_storage():
                           test_data.filename, store_data=True, analysis=bckg)
     classifier.run_all()
 
+    bckg.estimate()
     bckg.write()
 
     expected = np.full((test_data.energy_bins,),
                        ((integration-1)**2 + (integration-1)) /
-                       (2*test_data.livetime))
+                       (2*test_data.livetime*integration))
     results = np.genfromtxt('bckg_results.csv', delimiter=',', skip_header=1)
     np.testing.assert_almost_equal(results[0][2:], expected, decimal=3)
 

--- a/tests/test_BackgroundEstimator.py
+++ b/tests/test_BackgroundEstimator.py
@@ -49,7 +49,7 @@ def test_estimation():
     # the resulting observation should be:
     #   counts * integration / live-time
     expected = (((integration-1)**2 + (integration-1)) /
-                (2*test_data.livetime)) * test_data.energy_bins / integration
+                (2*test_data.livetime)) * test_data.energy_bins
     np.testing.assert_almost_equal(bckg.background.iloc[0][1],
                                    expected,
                                    decimal=3)
@@ -82,7 +82,7 @@ def test_write():
     # the resulting observation should be:
     #   counts * integration / live-time
     expected = (((integration-1)**2 + (integration-1)) /
-                (2*test_data.livetime)) * test_data.energy_bins / integration
+                (2*test_data.livetime)) * test_data.energy_bins
     np.testing.assert_almost_equal(results[0][1], expected, decimal=3)
 
     time_idx = np.where(spectra == 0)[0][0]


### PR DESCRIPTION
This introduces an analysis parameter class that plugs into `RadClass`: `BackgroundEstimator`. This small class processes gross count rates for each integrated time interval and sorts the set in ascending order of gross count rate magnitude. It then saves to a `.csv` file a percentage of the smallest count rates with corresponding timestamps.

A few notes:
- I have two "less-than-ideal" ways of writing the results to file. One way uses the class destructor `__del__` to write to file. This way, the file always is written at the end of an analysis script even if the script crashes. This does, however, require the class to be destructed if it is to be written and analyzed in the _same_ script (something I noticed when trying to write a test case). The alternative is to create a `write()` method which _must_ be called manually by a user script in order to be reviewed later. Which is better or should both be left in?
- ~~The method `save_all` currently does not work but should be considered. The idea would be to save the timestamps and the _spectra_ rather than the gross count rate. This way, the smallest (in gross count rate terms) spectra could be reviewed in post-analysis.~~