### PR TITLE
Adding a start/stop time Input to RadClass

### DIFF
--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -31,6 +31,9 @@ class RadClass:
     cache_size: Optional parameter to reduce file I/O and therefore
         increase performance. Indexes a larger selection of rows to analyze.
         If not provided (None), cache_size is ignored (equals integration).
+    start_time: Unix epoch timestamp, in units of seconds. All data in filename
+        at and after this point will be analyzed. Useful for processing only
+        a portion of a data file. Default: None, ignored.
     stop_time: Unix epoch timestamp, in units of seconds. All data in filename
         earlier and up to stop_time will be analyzed. Useful for processing
         only a portion of a data file. Default: None, ignored.
@@ -41,7 +44,8 @@ class RadClass:
     '''
 
     def __init__(self, stride, integration, datapath, filename, analysis=None,
-                 store_data=False, cache_size=None, stop_time=None,
+                 store_data=False, cache_size=None, start_time=None,
+                 stop_time=None,
                  labels={'live': '2x4x16LiveTimes',
                          'timestamps': '2x4x16Times',
                          'spectra': '2x4x16Spectra'}):
@@ -55,6 +59,7 @@ class RadClass:
         else:
             self.cache_size = cache_size
 
+        self.start_time = start_time
         self.stop_time = stop_time
         self.labels = labels
 
@@ -78,7 +83,10 @@ class RadClass:
         self.processor.init_database(self.filename, self.datapath)
         # parameters for keeping track of progress through a file
 
-        self.working_time = self.processor.timestamps[0]
+        if self.start_time is not None:
+            self.working_time = self.processor.timestamps[self.processor.timestamps > self.start_time][0]
+        else:
+            self.working_time = self.processor.timestamps[0]
         self.start_i = 0
 
     def collapse_data(self, rows_idx):

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -202,7 +202,7 @@ class RadClass:
         running = True  # tracks whether to end analysis
         while running:
             # print status at set intervals
-            if self.start_i % log_interval == 0:
+            if (self.start_i-offset) % log_interval == 0:
                 bar.update(round((self.start_i - offset) * inverse_dt, 4)*100)
 
                 readable_time = time.strftime('%m/%d/%Y %H:%M:%S',  time.gmtime(self.processor.timestamps[self.start_i]))

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -96,8 +96,7 @@ class RadClass:
                                                   self.start_time][0]
             self.start_i = np.where(self.processor.timestamps ==
                                     timestamp)[0][0]
-        else:
-            self.start_time = self.processor.timestamps[0]
+        self.start_time = self.processor.timestamps[self.start_i]
         self.current_i = self.start_i
 
         if self.stop_time is not None:
@@ -105,8 +104,7 @@ class RadClass:
                                                   self.stop_time][0]
             self.stop_i = np.where(self.processor.timestamps ==
                                    timestamp)[0][0]
-        else:
-            self.stop_time = self.processor.timestamps[-1]
+        self.stop_time = self.processor.timestamps[self.stop_i]
 
     def collapse_data(self, rows_idx):
         '''

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -96,6 +96,8 @@ class RadClass:
                                                   self.start_time][0]
             self.start_i = np.where(self.processor.timestamps ==
                                     timestamp)[0][0]
+        else:
+            self.start_time = self.processor.timestamps[0]
         self.current_i = self.start_i
 
         if self.stop_time is not None:
@@ -103,6 +105,8 @@ class RadClass:
                                                   self.stop_time][0]
             self.stop_i = np.where(self.processor.timestamps ==
                                    timestamp)[0][0]
+        else:
+            self.stop_time = self.processor.timestamps[-1]
 
     def collapse_data(self, rows_idx):
         '''
@@ -196,16 +200,17 @@ class RadClass:
         Only runs for a set node (datapath) with data already queued.
         '''
         bar = progressbar.ProgressBar(max_value=100, redirect_stdout=True)
-        inverse_dt = 1.0 / (self.stop_i - self.current_i)
+        inverse_dt = 1.0 / (self.stop_time - self.start_time)
 
         log_interval = 10000  # number of samples analyzed between log updates
         running = True  # tracks whether to end analysis
         while running:
             # print status at set intervals
-            if (self.current_i-self.start_i) % log_interval == 0:
-                bar.update(round((self.current_i - self.start_i) * inverse_dt, 4)*100)
+            current_time = self.processor.timestamps[self.current_i]
+            if (current_time - self.start_time) % log_interval == 0:
+                bar.update(round((current_time - self.start_time) * inverse_dt, 4)*100)
 
-                readable_time = time.strftime('%m/%d/%Y %H:%M:%S',  time.gmtime(self.processor.timestamps[self.current_i]))
+                readable_time = time.strftime('%m/%d/%Y %H:%M:%S',  time.gmtime(current_time))
                 logging.info("--\tCurrently working on timestamps: {}\n".format(readable_time))
 
             # execute analysis and advance in stride

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -37,6 +37,10 @@ class RadClass:
     stop_time: Unix epoch timestamp, in units of seconds. All data in filename
         earlier and up to stop_time will be analyzed. Useful for processing
         only a portion of a data file. Default: None, ignored.
+    NOTE: To convert from string to epoch, try:
+    time.mktime(datetime.datetime.strptime(x, "%m/%d/%Y %H:%M:%S").timetuple())
+    Where "%m/%d/%Y %H:%M:%S" is the string format (see datetime docs).
+    Requires time and datetime modules
     labels: list of dataset name labels in this order:
         [ live_label: live dataset name in HDF5 file,
           timestamps_label: timestamps dataset name in HDF5 file,

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -198,16 +198,17 @@ class RadClass:
         Only runs for a set node (datapath) with data already queued.
         '''
         bar = progressbar.ProgressBar(max_value=100, redirect_stdout=True)
-        inverse_dt = 1.0 / (self.stop_time - self.start_time)
+        inverse_dt = 1.0 / (self.stop_i - self.start_i)
 
-        log_interval = 10000  # number of samples analyzed between log updates
+        # number of samples analyzed between log updates
+        log_interval = max(min((self.stop_i - self.start_i)/100, 10000), 10) 
         running = True  # tracks whether to end analysis
         while running:
             # print status at set intervals
-            current_time = self.processor.timestamps[self.current_i]
-            if (current_time - self.start_time) % log_interval == 0:
-                bar.update(round((current_time - self.start_time) * inverse_dt, 4)*100)
+            if (self.current_i - self.start_i) % log_interval == 0:
+                bar.update(round((self.current_i - self.start_i) * inverse_dt, 4)*100)
 
+                current_time = self.processor.timestamps[self.current_i]
                 readable_time = time.strftime('%m/%d/%Y %H:%M:%S',  time.gmtime(current_time))
                 logging.info("--\tCurrently working on timestamps: {}\n".format(readable_time))
 

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -89,9 +89,10 @@ class RadClass:
 
         if self.start_time is not None:
             self.working_time = self.processor.timestamps[self.processor.timestamps > self.start_time][0]
+            self.start_i = np.where(self.processor.timestamps == self.working_time)[0][0]
         else:
             self.working_time = self.processor.timestamps[0]
-        self.start_i = 0
+            self.start_i = 0
 
     def collapse_data(self, rows_idx):
         '''

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -79,7 +79,9 @@ def test_integration():
 
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
-    expected = np.full((test_data.energy_bins,), integration*(integration-1)/2) / (integration*test_data.livetime)
+    expected = (np.full((test_data.energy_bins,),
+                        integration*(integration-1)/2) /
+                (integration*test_data.livetime))
     results = classifier.storage.to_numpy()[0]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
@@ -97,7 +99,9 @@ def test_cache():
 
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
-    expected = np.full((test_data.energy_bins,), integration*(integration-1)/2) / (integration*test_data.livetime)
+    expected = (np.full((test_data.energy_bins,),
+                        integration*(integration-1)/2) /
+                (integration*test_data.livetime))
     results = classifier.storage.to_numpy()[0]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
@@ -113,8 +117,11 @@ def test_stride():
 
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
-    integration_val = ((stride+integration)*(stride+integration-1)/2) - (stride*(stride-1)/2)
-    expected = np.full((test_data.energy_bins,), integration_val) / (integration*test_data.livetime)
+    integration_val = (((stride+integration)*(stride+integration-1)/2) -
+                       (stride*(stride-1)/2))
+    expected = (np.full((test_data.energy_bins,),
+                        integration_val) /
+                (integration*test_data.livetime))
     expected_samples = int(test_data.timesteps / stride)
     np.testing.assert_almost_equal(classifier.storage.iloc[1],
                                    expected,
@@ -135,7 +142,9 @@ def test_write():
 
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
-    expected = np.full((test_data.energy_bins,), integration*(integration-1)/2) / (integration*test_data.livetime)
+    expected = (np.full((test_data.energy_bins,),
+                        integration*(integration-1)/2) /
+                (integration*test_data.livetime))
     results = np.genfromtxt(filename, delimiter=',')[1, 1:]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
@@ -155,9 +164,14 @@ def test_start():
                           cache_size=cache_size, start_time=start_time)
     classifier.run_all()
 
-    integration_val = ((2*integration)*(2*integration-1)/2) - (integration*(integration-1)/2)
-    expected = np.full((test_data.energy_bins,), integration_val) / (integration*test_data.livetime)
-    np.testing.assert_almost_equal(classifier.storage.iloc[0], expected, decimal=2)
+    integration_val = (((2*integration)*(2*integration-1)/2) -
+                       (integration*(integration-1)/2))
+    expected = (np.full((test_data.energy_bins,),
+                        integration_val) /
+                (integration*test_data.livetime))
+    np.testing.assert_almost_equal(classifier.storage.iloc[0],
+                                   expected,
+                                   decimal=2)
     np.testing.assert_equal(len(classifier.storage), num_results-2)
 
 
@@ -178,8 +192,14 @@ def test_stop():
                           cache_size=cache_size, stop_time=stop_time)
     classifier.run_all()
 
-    integration_val = ((integration*(periods-1))*(integration*(periods-1)-1)/2 -
-                       (integration*(periods-2))*(integration*(periods-2)-1)/2)
-    expected = np.full((test_data.energy_bins,), integration_val) / (integration*test_data.livetime)
-    np.testing.assert_almost_equal(classifier.storage.iloc[-1], expected, decimal=2)
+    integration_val = (((integration*(periods-1)) *
+                        (integration*(periods-1)-1)/2) -
+                       ((integration*(periods-2)) *
+                        (integration*(periods-2)-1)/2))
+    expected = (np.full((test_data.energy_bins,),
+                        integration_val) /
+                (integration*test_data.livetime))
+    np.testing.assert_almost_equal(classifier.storage.iloc[-1],
+                                   expected,
+                                   decimal=2)
     np.testing.assert_equal(len(classifier.storage), periods-1)

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -148,6 +148,8 @@ def test_write():
     results = np.genfromtxt(filename, delimiter=',')[1, 1:]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
+    os.remove(filename)
+
 
 def test_start():
     num_results = 10

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -39,7 +39,8 @@ def test_analysis():
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename, analysis=NullAnalysis())
+                          test_data.filename, analysis=NullAnalysis(),
+                          store_data=False)
     classifier.run_all()
 
     np.testing.assert_equal(True, classifier.analysis.changed)
@@ -73,7 +74,7 @@ def test_integration():
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename)
+                          test_data.filename, store_data=False)
     classifier.run_all()
 
     # the resulting 1-hour observation should be:
@@ -90,7 +91,7 @@ def test_cache():
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename,
+                          test_data.filename, store_data=False,
                           cache_size=cache_size)
     classifier.run_all()
 
@@ -140,20 +141,21 @@ def test_write():
 
 
 def test_start():
-    stride = int(test_data.timesteps/10)
-    integration = int(test_data.timesteps/10)
+    num_results = 10
+
+    stride = int(test_data.timesteps/num_results)
+    integration = int(test_data.timesteps/num_results)
     cache_size = 100
     # start one integration period in
     start_time = timestamps[integration]
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename, store_data=True,
+                          test_data.filename, store_data=False,
                           cache_size=cache_size, start_time=start_time)
     classifier.run_all()
 
-    np.testing.assert_equal(len(classifier.storage),
-                            test_data.timesteps/integration-1)
+    np.testing.assert_equal(len(classifier.storage), num_results-2)
 
 
 def test_stop():
@@ -168,7 +170,7 @@ def test_stop():
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename, store_data=True,
+                          test_data.filename, store_data=False,
                           cache_size=cache_size, stop_time=stop_time)
     classifier.run_all()
 

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -160,13 +160,14 @@ def test_start():
 
 def test_stop():
     # arbitrary but results in less than # of timestamps
-    periods = 5
+    periods = 10
 
-    stride = int(test_data.timesteps/10)
-    integration = int(test_data.timesteps/10)
+    stride = int(test_data.timesteps/periods)
+    integration = int(test_data.timesteps/periods)
     cache_size = 100
-    # stop after n integration periods
-    stop_time = timestamps[integration*periods-1]
+    # stop after n-1 integration periods
+    # so n-1 results expected
+    stop_time = timestamps[integration*(periods-1)+1]
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
@@ -174,4 +175,4 @@ def test_stop():
                           cache_size=cache_size, stop_time=stop_time)
     classifier.run_all()
 
-    np.testing.assert_equal(len(classifier.storage), periods)
+    np.testing.assert_equal(len(classifier.storage), periods-1)

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -138,8 +138,6 @@ def test_write():
     results = np.genfromtxt(filename, delimiter=',')[1, 1:]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
-    os.remove('results.csv')
-
 
 def test_start():
     stride = int(test_data.timesteps/10)

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -49,10 +49,12 @@ def test_init():
     stride = 60
     integration = 60
     cache_size = 10000
+    stop_time = 2e9
 
     classifier = RadClass(stride=stride, integration=integration,
                           datapath=test_data.datapath,
-                          filename=test_data.filename, cache_size=cache_size,
+                          filename=test_data.filename, store_data=store_data,
+                          cache_size=cache_size, stop_time=stop_time,
                           labels=test_data.labels)
 
     np.testing.assert_equal(stride, classifier.stride)
@@ -60,6 +62,7 @@ def test_init():
     np.testing.assert_equal(test_data.datapath, classifier.datapath)
     np.testing.assert_equal(test_data.filename, classifier.filename)
     np.testing.assert_equal(cache_size, classifier.cache_size)
+    np.testing.assert_equal(stop_time, classifier.stop_time)
     np.testing.assert_equal(test_data.labels, classifier.labels)
 
 
@@ -134,4 +137,27 @@ def test_write():
     results = np.genfromtxt(filename, delimiter=',')[1, 1:]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
-    os.remove(filename)
+    os.remove('results.csv')
+
+
+def test_stop():
+    # arbitrary but results in less than # of timestamps
+    periods = 5
+
+    stride = 60
+    integration = 60
+    cache_size = 100
+    # stop after n integration periods
+    stop_time = timestamps[integration*periods-1]
+
+    # run handler script
+    classifier = RadClass(stride, integration, test_data.datapath,
+                          test_data.filename, store_data=True,
+                          cache_size=cache_size, stop_time=stop_time)
+    classifier.run_all()
+
+    results = np.genfromtxt('results.csv', delimiter=',')[1:]
+    print(results)
+    np.testing.assert_equal(len(results), periods)
+
+    os.remove('results.csv')

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -155,6 +155,9 @@ def test_start():
                           cache_size=cache_size, start_time=start_time)
     classifier.run_all()
 
+    integration_val = ((2*integration)*(2*integration-1)/2) - (integration*(integration-1)/2)
+    expected = np.full((test_data.energy_bins,), integration_val) / (integration*test_data.livetime)
+    np.testing.assert_almost_equal(classifier.storage.iloc[0], expected, decimal=2)
     np.testing.assert_equal(len(classifier.storage), num_results-2)
 
 
@@ -175,4 +178,8 @@ def test_stop():
                           cache_size=cache_size, stop_time=stop_time)
     classifier.run_all()
 
+    integration_val = ((integration*(periods-1))*(integration*(periods-1)-1)/2 -
+                       (integration*(periods-2))*(integration*(periods-2)-1)/2)
+    expected = np.full((test_data.energy_bins,), integration_val) / (integration*test_data.livetime)
+    np.testing.assert_almost_equal(classifier.storage.iloc[-1], expected, decimal=2)
     np.testing.assert_equal(len(classifier.storage), periods-1)

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -34,8 +34,8 @@ class NullAnalysis():
 
 
 def test_analysis():
-    stride = 60
-    integration = 60
+    stride = int(test_data.timesteps/10)
+    integration = int(test_data.timesteps/10)
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
@@ -46,8 +46,9 @@ def test_analysis():
 
 
 def test_init():
-    stride = 60
-    integration = 60
+    stride = int(test_data.timesteps/10)
+    integration = int(test_data.timesteps/10)
+    store_data = True
     cache_size = 10000
     stop_time = 2e9
 
@@ -67,8 +68,8 @@ def test_init():
 
 
 def test_integration():
-    stride = 60
-    integration = 60
+    stride = int(test_data.timesteps/10)
+    integration = int(test_data.timesteps/10)
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
@@ -83,8 +84,8 @@ def test_integration():
 
 
 def test_cache():
-    stride = 60
-    integration = 60
+    stride = int(test_data.timesteps/10)
+    integration = int(test_data.timesteps/10)
     cache_size = 100
 
     # run handler script
@@ -140,12 +141,29 @@ def test_write():
     os.remove('results.csv')
 
 
+def test_start():
+    stride = int(test_data.timesteps/10)
+    integration = int(test_data.timesteps/10)
+    cache_size = 100
+    # start one integration period in
+    start_time = timestamps[integration]
+
+    # run handler script
+    classifier = RadClass(stride, integration, test_data.datapath,
+                          test_data.filename, store_data=True,
+                          cache_size=cache_size, start_time=start_time)
+    classifier.run_all()
+
+    np.testing.assert_equal(len(classifier.storage),
+                            test_data.timesteps/integration-1)
+
+
 def test_stop():
     # arbitrary but results in less than # of timestamps
     periods = 5
 
-    stride = 60
-    integration = 60
+    stride = int(test_data.timesteps/10)
+    integration = int(test_data.timesteps/10)
     cache_size = 100
     # stop after n integration periods
     stop_time = timestamps[integration*periods-1]
@@ -156,8 +174,4 @@ def test_stop():
                           cache_size=cache_size, stop_time=stop_time)
     classifier.run_all()
 
-    results = np.genfromtxt('results.csv', delimiter=',')[1:]
-    print(results)
-    np.testing.assert_equal(len(results), periods)
-
-    os.remove('results.csv')
+    np.testing.assert_equal(len(classifier.storage), periods)


### PR DESCRIPTION
This PR adds an input variable `stop_time` that is a Unix epoch timestamp, in seconds. All data in filename earlier and up to `stop_time` will be analyzed. This is useful when only a portion of a file is needed for analysis (e.g. a week rather than the full month).
- It is the responsibility of the user that this input is less than the last timestamp in the data file (otherwise all data will be analyzed).
- It is the responsibility of the user than this is a float/integer in units of seconds, rather than a date string or otherwise. I am open to discussion on whether this should be a different format, leaving the conversion from string to float or otherwise to `RadClass`.