### PR TITLE
Adding test for stride and write method for RadClass

### DIFF
--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -27,7 +27,6 @@ class RadClass:
     filename: The filename for the data to be analyzed.
     TODO: Make node and filename -lists- so that multiple nodes and files
         can be processed by the same object.
-    store_data: boolean; if true, save the results to a CSV file.
     cache_size: (WIP) optional parameter to reduce file I/O and therefore
         increase performance. Indexes a larger selection of rows to analyze.
         If not provided (None), cache_size is ignored (equals integration).
@@ -38,7 +37,7 @@ class RadClass:
     '''
 
     def __init__(self, stride, integration, datapath, filename, analysis=None,
-                 store_data=False, cache_size=None,
+                 cache_size=None,
                  labels={'live': '2x4x16LiveTimes',
                          'timestamps': '2x4x16Times',
                          'spectra': '2x4x16Spectra'}):
@@ -47,7 +46,6 @@ class RadClass:
         self.datapath = datapath
         self.filename = filename
 
-        self.store_data = store_data
         if cache_size is None:
             self.cache_size = self.integration
         else:
@@ -194,8 +192,7 @@ class RadClass:
             if self.analysis is not None:
                 self.analysis.run(data)
 
-            if self.store_data:
-                self.storage = pd.concat([self.storage, pd.DataFrame([data], index=[self.working_time])])
+            self.storage = pd.concat([self.storage, pd.DataFrame([data], index=[self.working_time])])
 
             running = self.march()
 
@@ -211,13 +208,16 @@ class RadClass:
         may be better for debugging and development.
         '''
 
-        if self.store_data:
-            self.storage = pd.DataFrame()
+        self.storage = pd.DataFrame()
 
         self.queue_file()
         # initialize cache
         self.run_cache()
         self.iterate()
 
-        if self.store_data:
-            self.storage.to_csv('results.csv')
+    def write(self, filename):
+        '''
+        Write results to file using Pandas' to_csv() method.
+        filename should include the file extension.
+        '''
+        self.storage.to_csv(filename)

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -39,8 +39,7 @@ def test_analysis():
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename, analysis=NullAnalysis(),
-                          store_data=True)
+                          test_data.filename, analysis=NullAnalysis())
     classifier.run_all()
 
     np.testing.assert_equal(True, classifier.analysis.changed)
@@ -49,19 +48,17 @@ def test_analysis():
 def test_init():
     stride = 60
     integration = 60
-    store_data = True
     cache_size = 10000
 
     classifier = RadClass(stride=stride, integration=integration,
                           datapath=test_data.datapath,
-                          filename=test_data.filename, store_data=store_data,
-                          cache_size=cache_size, labels=test_data.labels)
+                          filename=test_data.filename, cache_size=cache_size,
+                          labels=test_data.labels)
 
     np.testing.assert_equal(stride, classifier.stride)
     np.testing.assert_equal(integration, classifier.integration)
     np.testing.assert_equal(test_data.datapath, classifier.datapath)
     np.testing.assert_equal(test_data.filename, classifier.filename)
-    np.testing.assert_equal(store_data, classifier.store_data)
     np.testing.assert_equal(cache_size, classifier.cache_size)
     np.testing.assert_equal(test_data.labels, classifier.labels)
 
@@ -72,16 +69,14 @@ def test_integration():
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename, store_data=True)
+                          test_data.filename)
     classifier.run_all()
 
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
-    expected = spectra / test_data.livetime
-    results = np.genfromtxt('results.csv', delimiter=',')[1, 1:]
+    expected = spectra * integration / test_data.livetime
+    results = classifier.storage.to_numpy()[1]
     np.testing.assert_almost_equal(results, expected[0], decimal=2)
-
-    os.remove('results.csv')
 
 
 def test_cache():
@@ -91,17 +86,15 @@ def test_cache():
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename, store_data=True,
+                          test_data.filename,
                           cache_size=cache_size)
     classifier.run_all()
 
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
-    expected = spectra / test_data.livetime
-    results = np.genfromtxt('results.csv', delimiter=',')[1, 1:]
+    expected = spectra * integration / test_data.livetime
+    results = classifier.storage.to_numpy()[1]
     np.testing.assert_almost_equal(results, expected[0], decimal=2)
-
-    os.remove('results.csv')
 
 
 def test_stride():
@@ -110,7 +103,7 @@ def test_stride():
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename, store_data=True)
+                          test_data.filename)
     classifier.run_all()
 
     # the resulting 1-hour observation should be:
@@ -118,8 +111,27 @@ def test_stride():
     expected = spectra * integration / test_data.livetime
     expected_samples = int(test_data.timesteps /
                            (integration + (stride - integration)))
-    results = np.genfromtxt('results.csv', delimiter=',')[1:, 1:]
-    np.testing.assert_almost_equal(results[0], expected[0], decimal=2)
-    np.testing.assert_equal(len(results), expected_samples)
+    np.testing.assert_almost_equal(classifier.storage.iloc[0],
+                                   expected[0],
+                                   decimal=2)
+    np.testing.assert_equal(len(classifier.storage), expected_samples)
 
-    os.remove('results.csv')
+
+def test_write():
+    stride = 60
+    integration = 60
+    filename = 'test_results.csv'
+
+    # run handler script
+    classifier = RadClass(stride, integration, test_data.datapath,
+                          test_data.filename)
+    classifier.run_all()
+    classifier.write(filename)
+
+    # the resulting 1-hour observation should be:
+    #   counts * integration / live-time
+    expected = spectra * integration / test_data.livetime
+    results = np.genfromtxt(filename, delimiter=',')[1, 1:]
+    np.testing.assert_almost_equal(results, expected[0], decimal=2)
+
+    os.remove(filename)

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -102,3 +102,24 @@ def test_cache():
     np.testing.assert_almost_equal(results, expected[0], decimal=2)
 
     os.remove('results.csv')
+
+
+def test_stride():
+    stride = 100
+    integration = 50
+
+    # run handler script
+    classifier = RadClass(stride, integration, test_data.datapath,
+                          test_data.filename, store_data=True)
+    classifier.run_all()
+
+    # the resulting 1-hour observation should be:
+    #   counts * integration / live-time
+    expected = spectra * integration / test_data.livetime
+    expected_samples = int(test_data.timesteps /
+                           (integration + (stride - integration)))
+    results = np.genfromtxt('results.csv', delimiter=',')[1:, 1:]
+    np.testing.assert_almost_equal(results[0], expected[0], decimal=2)
+    np.testing.assert_equal(len(results), expected_samples)
+
+    os.remove('results.csv')

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -74,7 +74,7 @@ def test_integration():
 
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
-    expected = np.full((test_data.energy_bins,), integration*(integration-1)/2) / test_data.livetime
+    expected = np.full((test_data.energy_bins,), integration*(integration-1)/2) / (integration*test_data.livetime)
     results = classifier.storage.to_numpy()[0]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
@@ -92,7 +92,7 @@ def test_cache():
 
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
-    expected = np.full((test_data.energy_bins,), integration*(integration-1)/2) / test_data.livetime
+    expected = np.full((test_data.energy_bins,), integration*(integration-1)/2) / (integration*test_data.livetime)
     results = classifier.storage.to_numpy()[0]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
@@ -109,7 +109,7 @@ def test_stride():
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
     integration_val = ((stride+integration)*(stride+integration-1)/2) - (stride*(stride-1)/2)
-    expected = np.full((test_data.energy_bins,), integration_val) / test_data.livetime
+    expected = np.full((test_data.energy_bins,), integration_val) / (integration*test_data.livetime)
     expected_samples = int(test_data.timesteps / stride)
     np.testing.assert_almost_equal(classifier.storage.iloc[1],
                                    expected,
@@ -130,7 +130,7 @@ def test_write():
 
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
-    expected = np.full((test_data.energy_bins,), integration*(integration-1)/2) / test_data.livetime
+    expected = np.full((test_data.energy_bins,), integration*(integration-1)/2) / (integration*test_data.livetime)
     results = np.genfromtxt(filename, delimiter=',')[1, 1:]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 


### PR DESCRIPTION
Includes a test to ensure the `stride` variable is working correctly in RadClass. The test compares the length of the results and compares it to the expected number of samples when using a specified stride and integration. Resolves #13.

`stride` should advance the working timestamp, which varies independently of `integration`. This allows the integration window to overlap or be spaced out.

`RadClass` is also tweaked slightly, removing the `store_data` member variable. Instead, a `write()` method is included. Therefore, writing to file will no longer be automatic, but can be controlled by the user.