### PR TITLE
correcting integration bug for data

### DIFF
--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -103,7 +103,7 @@ class RadClass:
         # for row in data_matrix:
         #    total += row
         # utilizes numpy architecture to sum data
-        total = np.sum(data_matrix, axis=0)
+        total = np.sum(data_matrix, axis=0) / self.integration
 
         return total
 

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -77,7 +77,7 @@ def test_integration():
 
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
-    expected = spectra * integration / test_data.livetime
+    expected = spectra / test_data.livetime
     results = np.genfromtxt('results.csv', delimiter=',')[1, 1:]
     np.testing.assert_almost_equal(results, expected[0], decimal=2)
 
@@ -97,7 +97,7 @@ def test_cache():
 
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
-    expected = spectra * integration / test_data.livetime
+    expected = spectra / test_data.livetime
     results = np.genfromtxt('results.csv', delimiter=',')[1, 1:]
     np.testing.assert_almost_equal(results, expected[0], decimal=2)
 


### PR DESCRIPTION
`RadClass` is not reporting the correct count-rate per channel because one portion of the integration process is not included. For a set of `n` rows to be integrated, each individual row should be corrected by its corresponding live time and then summed. Before this sum is returned, it should also be divided by `n`, the integration time. This is added here.