### PR TITLE
replacing pd.concat with dict build

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -206,7 +206,7 @@ class RadClass:
         while running:
             # print status at set intervals
             if (self.current_i - self.start_i) % log_interval == 0:
-                bar.update(round((self.current_i - self.start_i) * inverse_dt, 4)*100)
+                bar.update(round((self.current_i - self.start_i) * inverse_dt * 100, 4))
 
                 current_time = self.processor.timestamps[self.current_i]
                 readable_time = time.strftime('%m/%d/%Y %H:%M:%S',  time.gmtime(current_time))
@@ -220,7 +220,7 @@ class RadClass:
             if self.analysis is not None:
                 self.analysis.run(data)
 
-            self.storage[self.working_time] = data
+            self.storage[self.processor.timestamps[self.current_i]] = data
 
             running = self.march()
 

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -243,12 +243,13 @@ class RadClass:
         self.run_cache()
         self.iterate()
 
+        self.storage = pd.DataFrame.from_dict(self.storage,
+                                              orient='index',
+                                              columns=np.arange(len(self.cache[0])))
+
     def write(self, filename):
         '''
         Write results to file using Pandas' to_csv() method.
         filename should include the file extension.
         '''
-        self.storage = pd.DataFrame.from_dict(self.storage,
-                                              orient='index',
-                                              columns=np.arange(len(self.cache[0])))
         self.storage.to_csv(filename)

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -220,7 +220,7 @@ class RadClass:
             if self.analysis is not None:
                 self.analysis.run(data)
 
-            self.storage = pd.concat([self.storage, pd.DataFrame([data], index=[self.processor.timestamps[self.current_i]])])
+            self.storage[self.working_time] = data
 
             running = self.march()
 
@@ -236,7 +236,7 @@ class RadClass:
         may be better for debugging and development.
         '''
 
-        self.storage = pd.DataFrame()
+        self.storage = dict()
 
         self.queue_file()
         # initialize cache
@@ -248,4 +248,7 @@ class RadClass:
         Write results to file using Pandas' to_csv() method.
         filename should include the file extension.
         '''
+        self.storage = pd.DataFrame.from_dict(self.storage,
+                                              orient='index',
+                                              columns=np.arange(len(self.cache[0])))
         self.storage.to_csv(filename)


### PR DESCRIPTION
This is a small change to `self.storage` in RadClass, now utilizing `dict()` instead of `pd.concat` to store/build results. This is inspired by a conversation with @kkiesling (thanks!). I like that this makes minimal assumptions about the number of results/data structure and minimizes reliance on pandas.

For reference, I conducted a [line_profiler](https://github.com/pyutils/line_profiler#frequently-asked-questions) before and after changes. The new method can process an entire month of data (with no `AnalysisParameter`) in approximately 6 minutes, with 0.1 seconds spent on `self.storage[self.working_time] = data` and about 97 seconds spent on `RadClass.write()`. Meanwhile, I abandonded profiling the original changes, as it was 14% complete with an ETA of 1.5 hours!

**I recommend waiting to merge this until after #16, since that removes `self.working_time` and thus a rebase/edit will be required.**