### PR TITLE
setting tracked timestamp to x1 rather than x2 in H-test

### DIFF
--- a/RadClass/H0.py
+++ b/RadClass/H0.py
@@ -51,6 +51,7 @@ class H0:
         # only needed for the first initialization
         if self.x1 is None:
             self.x1 = data
+            self.x1_timestamp = timestamp
         else:
             self.x2 = data
             n = self.x1 + self.x2
@@ -60,17 +61,19 @@ class H0:
             # only save instances with rejected null hypothesesf
             if pval <= self.significance:
                 self.triggers = np.append(self.triggers,
-                                            [[timestamp, pval,
+                                            [[self.x1_timestamp, pval,
                                             self.x1, self.x2]],
                                             axis=0)
 
             # saving data for the next integration step
             self.x1 = self.x2
+            self.x1_timestamp = timestamp
     
     def run_channels(self, data, timestamp):
         # only needed for the first initialization
         if self.x1 is None:
             self.x1 = data
+            self.x1_timestamp = timestamp
         else:
             self.x2 = data
             rejections = np.ones_like(data)
@@ -85,11 +88,12 @@ class H0:
             if np.sum(rejections) != len(rejections):
                 self.triggers = np.append(self.triggers,
                                         [np.insert(rejections,
-                                                    0, timestamp)],
+                                                    0, self.x1_timestamp)],
                                         axis=0)
 
             # saving data for the next integration step
             self.x1 = self.x2
+            self.x1_timestamp = timestamp
 
     def run(self, data, timestamp):
         '''

--- a/tests/test_H0.py
+++ b/tests/test_H0.py
@@ -53,10 +53,14 @@ def test_gross():
                           test_data.filename, analysis=analysis)
     classifier.run_all()
 
-    np.testing.assert_equal(analysis.triggers[0][0],
-                            timestamps[-(rejected_H0_time+integration)])
+    obs_timestamp = analysis.triggers[0][0]
+    exp_timestamp = timestamps[-(rejected_H0_time+integration)]
+    np.testing.assert_equal(obs_timestamp,
+                            exp_timestamp)
     # there should only be one rejected hypothesis
-    np.testing.assert_equal(analysis.triggers.shape[0], 1)
+    obs_rows = analysis.triggers.shape[0]
+    exp_rows = 1
+    np.testing.assert_equal(obs_rows, exp_rows)
 
 
 def test_channel():
@@ -69,12 +73,18 @@ def test_channel():
                           test_data.filename, analysis=analysis)
     classifier.run_all()
 
-    np.testing.assert_equal(analysis.triggers[0][0],
-                            timestamps[-(rejected_H0_time+integration)])
+    obs_timestamp = analysis.triggers[0][0]
+    exp_timestamp = timestamps[-(rejected_H0_time+integration)]
+    np.testing.assert_equal(obs_timestamp,
+                            exp_timestamp)
     # there should only be one rejected hypothesis
-    np.testing.assert_equal(analysis.triggers.shape[0], 1)
+    obs_rows = analysis.triggers.shape[0]
+    exp_rows = 1
+    np.testing.assert_equal(obs_rows, exp_rows)
     # columns = 1 for timestamp + energy_bins
-    np.testing.assert_equal(analysis.triggers.shape[1], test_data.energy_bins+1)
+    obs_cols = analysis.triggers.shape[1]
+    exp_cols = test_data.energy_bins+1
+    np.testing.assert_equal(obs_cols, exp_cols)
 
 
 def test_write_gross():
@@ -91,7 +101,9 @@ def test_write_gross():
 
     results = np.genfromtxt(filename, delimiter=',')[1:]
     # 5 columns are required since the index is also saved (via pandas)
-    np.testing.assert_equal(results.shape, (1, 5))
+    obs = results.shape
+    exp = (1, 5)
+    np.testing.assert_equal(obs, exp)
 
     os.remove(filename)
 
@@ -110,6 +122,8 @@ def test_write_channel():
 
     results = np.genfromtxt(filename, delimiter=',')[1:]
     # 2 extra columns are required for timestamp and index (via pandas)
-    np.testing.assert_equal(results.shape, (1, test_data.energy_bins+2))
+    obs = results.shape
+    exp = (1, test_data.energy_bins+2)
+    np.testing.assert_equal(obs, exp)
 
     os.remove(filename)

--- a/tests/test_H0.py
+++ b/tests/test_H0.py
@@ -54,7 +54,7 @@ def test_gross():
     classifier.run_all()
 
     np.testing.assert_equal(analysis.triggers[0][0],
-                            timestamps[-rejected_H0_time])
+                            timestamps[-(rejected_H0_time+integration)])
     # there should only be one rejected hypothesis
     np.testing.assert_equal(analysis.triggers.shape[0], 1)
 
@@ -70,7 +70,7 @@ def test_channel():
     classifier.run_all()
 
     np.testing.assert_equal(analysis.triggers[0][0],
-                            timestamps[-rejected_H0_time])
+                            timestamps[-(rejected_H0_time+integration)])
     # there should only be one rejected hypothesis
     np.testing.assert_equal(analysis.triggers.shape[0], 1)
     # columns = 1 for timestamp + energy_bins


### PR DESCRIPTION
Addresses #21. Creates a member variable called `x1_timestamp` to store input `timestamp` from `RadClass` associated with the first measurement in a hypothesis test: `x1`. This is preferable since, in the event of a rapid decrease that causes the null hypothesis to be rejected (which is anecdotally more common), the first timestamp is more relevantly associated with the *event* spectrum.