### PR TITLE
re-adding functionality of RadClass.store_data

### DIFF
--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -245,10 +245,9 @@ class RadClass:
         self.run_cache()
         self.iterate()
 
-        if self.store_data:
-            self.storage = pd.DataFrame.from_dict(self.storage,
-                                                  orient='index',
-                                                  columns=np.arange(len(self.cache[0])))
+        self.storage = pd.DataFrame.from_dict(self.storage,
+                                                orient='index',
+                                                columns=np.arange(len(self.cache[0])))
 
     def write(self, filename):
         '''

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -49,7 +49,7 @@ class RadClass:
     '''
 
     def __init__(self, stride, integration, datapath, filename, analysis=None,
-                 store_data=False, cache_size=None, start_time=None,
+                 store_data=True, cache_size=None, start_time=None,
                  stop_time=None,
                  labels={'live': '2x4x16LiveTimes',
                          'timestamps': '2x4x16Times',
@@ -58,6 +58,7 @@ class RadClass:
         self.integration = integration
         self.datapath = datapath
         self.filename = filename
+        self.store_data = store_data
 
         if cache_size is None:
             self.cache_size = self.integration
@@ -220,8 +221,8 @@ class RadClass:
             if self.analysis is not None:
                 self.analysis.run(data,
                                   self.processor.timestamps[self.current_i])
-
-            self.storage[self.processor.timestamps[self.current_i]] = data
+            if self.store_data:
+                self.storage[self.processor.timestamps[self.current_i]] = data
 
             running = self.march()
 
@@ -244,9 +245,10 @@ class RadClass:
         self.run_cache()
         self.iterate()
 
-        self.storage = pd.DataFrame.from_dict(self.storage,
-                                              orient='index',
-                                              columns=np.arange(len(self.cache[0])))
+        if self.store_data:
+            self.storage = pd.DataFrame.from_dict(self.storage,
+                                                  orient='index',
+                                                  columns=np.arange(len(self.cache[0])))
 
     def write(self, filename):
         '''

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -125,7 +125,8 @@ class RadClass:
         # normalize by live times to produce count rate data
         # processor.live can be indexed by appropriate timestamps
         # (i.e. row indices).
-        data_matrix = self.cache[rows_idx-self.cache_idx[0]] / self.processor.live[rows_idx][:, None]
+        data_matrix = (self.cache[rows_idx-self.cache_idx[0]] /
+                       self.processor.live[rows_idx][:, None])
 
         # old, more inefficient way of summing
         # total = np.zeros_like(data_matrix[0])
@@ -202,7 +203,7 @@ class RadClass:
         inverse_dt = 1.0 / (self.stop_i - self.start_i)
 
         # number of samples analyzed between log updates
-        log_interval = max(min((self.stop_i - self.start_i)/100, 10000), 10) 
+        log_interval = max(min((self.stop_i - self.start_i)/100, 10000), 10)
         running = True  # tracks whether to end analysis
         while running:
             # print status at set intervals
@@ -246,8 +247,8 @@ class RadClass:
         self.iterate()
 
         self.storage = pd.DataFrame.from_dict(self.storage,
-                                                orient='index',
-                                                columns=np.arange(len(self.cache[0])))
+                                              orient='index',
+                                              columns=np.arange(len(self.cache[0])))
 
     def write(self, filename):
         '''

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -74,7 +74,7 @@ def test_integration():
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename, store_data=False)
+                          test_data.filename, store_data=True)
     classifier.run_all()
 
     # the resulting 1-hour observation should be:
@@ -93,7 +93,7 @@ def test_cache():
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename, store_data=False,
+                          test_data.filename, store_data=True,
                           cache_size=cache_size)
     classifier.run_all()
 
@@ -162,7 +162,7 @@ def test_start():
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename, store_data=False,
+                          test_data.filename, store_data=True,
                           cache_size=cache_size, start_time=start_time)
     classifier.run_all()
 
@@ -190,7 +190,7 @@ def test_stop():
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
-                          test_data.filename, store_data=False,
+                          test_data.filename, store_data=True,
                           cache_size=cache_size, stop_time=stop_time)
     classifier.run_all()
 


### PR DESCRIPTION
This adds functionality to the `RadClass` attribute `store_data`. If `True`, all spectral information processed will be stored in a dictionary->Pandas DataFrame called `RadClass.storage`. Thus, data can be written to file using `RadClass.write()`. If `False`, no data will be saved to `RadClass.storage`, even though it still exists.