### PR TITLE
change average to integration

### DIFF
--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -126,12 +126,8 @@ class RadClass:
         # (i.e. row indices).
         data_matrix = self.cache[rows_idx-self.cache_idx[0]] / self.processor.live[rows_idx][:, None]
 
-        # old, more inefficient way of summing
-        # total = np.zeros_like(data_matrix[0])
-        # for row in data_matrix:
-        #    total += row
         # utilizes numpy architecture to sum data
-        total = np.sum(data_matrix, axis=0) / self.integration
+        total = np.sum(data_matrix, axis=0)
 
         return total
 

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -81,7 +81,7 @@ def test_integration():
     #   counts * integration / live-time
     expected = (np.full((test_data.energy_bins,),
                         integration*(integration-1)/2) /
-                (integration*test_data.livetime))
+                test_data.livetime)
     results = classifier.storage.to_numpy()[0]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
@@ -101,7 +101,7 @@ def test_cache():
     #   counts * integration / live-time
     expected = (np.full((test_data.energy_bins,),
                         integration*(integration-1)/2) /
-                (integration*test_data.livetime))
+                test_data.livetime)
     results = classifier.storage.to_numpy()[0]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
@@ -121,7 +121,7 @@ def test_stride():
                        (stride*(stride-1)/2))
     expected = (np.full((test_data.energy_bins,),
                         integration_val) /
-                (integration*test_data.livetime))
+                test_data.livetime)
     expected_samples = int(test_data.timesteps / stride)
     np.testing.assert_almost_equal(classifier.storage.iloc[1],
                                    expected,
@@ -144,7 +144,7 @@ def test_write():
     #   counts * integration / live-time
     expected = (np.full((test_data.energy_bins,),
                         integration*(integration-1)/2) /
-                (integration*test_data.livetime))
+                test_data.livetime)
     results = np.genfromtxt(filename, delimiter=',')[1, 1:]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
@@ -170,7 +170,7 @@ def test_start():
                        (integration*(integration-1)/2))
     expected = (np.full((test_data.energy_bins,),
                         integration_val) /
-                (integration*test_data.livetime))
+                test_data.livetime)
     np.testing.assert_almost_equal(classifier.storage.iloc[0],
                                    expected,
                                    decimal=2)
@@ -200,7 +200,7 @@ def test_stop():
                         (integration*(periods-2)-1)/2))
     expected = (np.full((test_data.energy_bins,),
                         integration_val) /
-                (integration*test_data.livetime))
+                test_data.livetime)
     np.testing.assert_almost_equal(classifier.storage.iloc[-1],
                                    expected,
                                    decimal=2)


### PR DESCRIPTION
This removes the division by integration size when collapsing rows. This changing the calculation from an _average_ to an _integration_. This matches the Poisson statistics of the hypothesis test.