### PR TITLE
Removing Pandas and Improving Write-to-File

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Versions 3.6-3.9 are currently supported by tests. The following Python packages
 
 * h5py
 * numpy
-* pandas
 * progressbar2
 * scipy
 

--- a/RadClass/H0.py
+++ b/RadClass/H0.py
@@ -121,4 +121,7 @@ class H0:
             for i in range(len(self.triggers[0, 1:])):
                 results[str(i)] = self.triggers[:, i]
 
-        results.to_csv(filename, sep=',')
+        with open(filename, 'a') as f:
+            results.to_csv(f,
+                           sep=',',
+                           header=f.tell()==0)

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 import time
 import logging
 import progressbar
@@ -183,6 +182,10 @@ class RadClass:
         return running
 
     def run_cache(self):
+        '''
+        Updates RadClass.cache to contain the requisite rows needed for
+        integration. Tracked via indices and cache_size.
+        '''
         end_i = min(self.current_i + self.cache_size,
                     len(self.processor.timestamps) - 1)
         # enumerate number of rows to integrate exclusive of the endpoint
@@ -195,7 +198,7 @@ class RadClass:
         until EOF reached. Prints progress over the course of the analysis.
         Only runs for a set node (datapath) with data already queued.
         '''
-        bar = progressbar.ProgressBar(max_value=100, redirect_stdout=True)
+        pbar = progressbar.ProgressBar(max_value=100, redirect_stdout=True)
         inverse_dt = 1.0 / (self.stop_i - self.start_i)
 
         # number of samples analyzed between log updates
@@ -204,11 +207,11 @@ class RadClass:
         while running:
             # print status at set intervals
             if (self.current_i - self.start_i) % log_interval == 0:
-                bar.update(round((self.current_i - self.start_i) * inverse_dt * 100, 4))
+                pbar.update(round((self.current_i - self.start_i) * inverse_dt * 100, 4))
 
                 current_time = self.processor.timestamps[self.current_i]
                 readable_time = time.strftime('%m/%d/%Y %H:%M:%S',  time.gmtime(current_time))
-                logging.info("--\tCurrently working on timestamps: {}\n".format(readable_time))
+                logging.info("--\tCurrently working on timestamps: %d\n", readable_time)
 
             # execute analysis and advance in stride
             rows_idx = self.collect_rows()
@@ -225,7 +228,7 @@ class RadClass:
 
         # print completion summary
         logging.info("\n...Complete...")
-        logging.info("Finished analyzing {}.\n\tNumber of observations analyzed: {}".format(self.filename, len(self.processor.timestamps)))
+        logging.info("Finished analyzing %s.\n\tNumber of observations analyzed: %d", self.filename, len(self.processor.timestamps))
 
     def run_all(self):
         '''
@@ -242,16 +245,26 @@ class RadClass:
         self.run_cache()
         self.iterate()
 
-        self.storage = pd.DataFrame.from_dict(self.storage,
-                                              orient='index',
-                                              columns=np.arange(len(self.cache[0])))
+        # do not convert to numpy array if empty
+        if bool(self.storage):
+            self.storage = np.insert(arr=np.array(list(self.storage.values())),
+                                     obj=0,
+                                     values=list(self.storage.keys()),
+                                     axis=1)
 
     def write(self, filename):
         '''
-        Write results to file using Pandas' to_csv() method.
+        Write results to file using numpy.savetxt() method.
         filename should include the file extension.
         '''
         with open(filename, 'a') as f:
-            self.storage.to_csv(f,
-                                sep=',',
-                                header=f.tell()==0)
+            header = ''
+            # build/include header if file is new
+            if f.tell() == 0:
+                header = np.append(['timestamp'],
+                                   np.arange(len(self.cache[0])).astype(str))
+                header = ', '.join(col for col in header)
+            np.savetxt(fname=f,
+                       X=self.storage,
+                       delimiter=',',
+                       header=header)

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -199,7 +199,7 @@ class RadClass:
         inverse_dt = 1.0 / (self.stop_i - self.start_i)
 
         # number of samples analyzed between log updates
-        log_interval = max(min((self.stop_i - self.start_i)/100, 10000), 10)
+        log_interval = max(min((self.stop_i - self.start_i)/100, 100), 10)
         running = True  # tracks whether to end analysis
         while running:
             # print status at set intervals
@@ -251,4 +251,7 @@ class RadClass:
         Write results to file using Pandas' to_csv() method.
         filename should include the file extension.
         '''
-        self.storage.to_csv(filename)
+        with open(filename, 'a') as f:
+            self.storage.to_csv(f,
+                                sep=',',
+                                header=f.tell()==0)

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -94,14 +94,18 @@ class RadClass:
         if self.start_time is not None:
             timestamp = self.processor.timestamps[self.processor.timestamps >=
                                                   self.start_time][0]
-            self.start_i = np.abs(self.processor.timestamps - timestamp).argmin()
+            self.start_i = max(np.searchsorted(self.processor.timestamps,
+                                               timestamp,
+                                               side='right')-1, 0)
         self.start_time = self.processor.timestamps[self.start_i]
         self.current_i = self.start_i
 
         if self.stop_time is not None:
             timestamp = self.processor.timestamps[self.processor.timestamps >=
                                                   self.stop_time][0]
-            self.stop_i = np.abs(self.processor.timestamps - timestamp).argmin()
+            self.stop_i = np.searchsorted(self.processor.timestamps,
+                                          timestamp,
+                                          side='right')-1
         self.stop_time = self.processor.timestamps[self.stop_i]
 
     def collapse_data(self, rows_idx):

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -94,16 +94,14 @@ class RadClass:
         if self.start_time is not None:
             timestamp = self.processor.timestamps[self.processor.timestamps >=
                                                   self.start_time][0]
-            self.start_i = np.where(self.processor.timestamps ==
-                                    timestamp)[0][0]
+            self.start_i = np.abs(self.processor.timestamps - timestamp).argmin()
         self.start_time = self.processor.timestamps[self.start_i]
         self.current_i = self.start_i
 
         if self.stop_time is not None:
             timestamp = self.processor.timestamps[self.processor.timestamps >=
                                                   self.stop_time][0]
-            self.stop_i = np.where(self.processor.timestamps ==
-                                   timestamp)[0][0]
+            self.stop_i = np.abs(self.processor.timestamps - timestamp).argmin()
         self.stop_time = self.processor.timestamps[self.stop_i]
 
     def collapse_data(self, rows_idx):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy
 h5py
-pandas
 progressbar2
 scipy

--- a/tests/test_H0.py
+++ b/tests/test_H0.py
@@ -90,7 +90,7 @@ def test_channel():
 def test_write_gross():
     stride = 10
     integration = 10
-    filename = 'h0test.csv'
+    filename = 'h0test_gross.csv'
 
     # run handler script with analysis parameter
     analysis = H0()
@@ -99,10 +99,10 @@ def test_write_gross():
     classifier.run_all()
     analysis.write(filename)
 
-    results = np.genfromtxt(filename, delimiter=',')[1:]
-    # 5 columns are required since the index is also saved (via pandas)
+    results = np.loadtxt(filename, delimiter=',')
+    # expected shape is only 1D because only 1 entry is expected
     obs = results.shape
-    exp = (1, 5)
+    exp = (4,)
     np.testing.assert_equal(obs, exp)
 
     os.remove(filename)
@@ -111,7 +111,7 @@ def test_write_gross():
 def test_write_channel():
     stride = 10
     integration = 10
-    filename = 'h0test.csv'
+    filename = 'h0test_channel.csv'
 
     # run handler script with analysis parameter
     analysis = H0(gross=False, energy_bins=test_data.energy_bins)
@@ -120,10 +120,11 @@ def test_write_channel():
     classifier.run_all()
     analysis.write(filename)
 
-    results = np.genfromtxt(filename, delimiter=',')[1:]
-    # 2 extra columns are required for timestamp and index (via pandas)
+    results = np.loadtxt(filename, delimiter=',')
+    # 1 extra columns are required for timestamp
+    # expected shape is only 1D because only 1 entry is expected
     obs = results.shape
-    exp = (1, test_data.energy_bins+2)
+    exp = (test_data.energy_bins+1,)
     np.testing.assert_equal(obs, exp)
 
     os.remove(filename)

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -83,7 +83,6 @@ def test_integration():
                         integration*(integration-1)/2) /
                 test_data.livetime)
     results = classifier.storage[0][1:][0]
-    print(results)
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
 

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -146,7 +146,9 @@ def test_write():
     expected = (np.full((test_data.energy_bins,),
                         integration*(integration-1)/2) /
                 test_data.livetime)
-    results = np.loadtxt(filename, delimiter=',')[0, 1:]
+    # results array is only 1D because only one entry is expected
+    # for test_data.timesteps
+    results = np.loadtxt(filename, delimiter=',')[1:]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
     os.remove(filename)

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -82,7 +82,8 @@ def test_integration():
     expected = (np.full((test_data.energy_bins,),
                         integration*(integration-1)/2) /
                 test_data.livetime)
-    results = classifier.storage.to_numpy()[0]
+    results = classifier.storage[0][1:][0]
+    print(results)
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
 
@@ -102,7 +103,7 @@ def test_cache():
     expected = (np.full((test_data.energy_bins,),
                         integration*(integration-1)/2) /
                 test_data.livetime)
-    results = classifier.storage.to_numpy()[0]
+    results = classifier.storage[0, 1:]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
 
@@ -123,7 +124,7 @@ def test_stride():
                         integration_val) /
                 test_data.livetime)
     expected_samples = int(test_data.timesteps / stride)
-    np.testing.assert_almost_equal(classifier.storage.iloc[1],
+    np.testing.assert_almost_equal(classifier.storage[1, 1:],
                                    expected,
                                    decimal=2)
     np.testing.assert_equal(len(classifier.storage), expected_samples)
@@ -145,7 +146,7 @@ def test_write():
     expected = (np.full((test_data.energy_bins,),
                         integration*(integration-1)/2) /
                 test_data.livetime)
-    results = np.genfromtxt(filename, delimiter=',')[1, 1:]
+    results = np.loadtxt(filename, delimiter=',')[0, 1:]
     np.testing.assert_almost_equal(results, expected, decimal=2)
 
     os.remove(filename)
@@ -171,7 +172,7 @@ def test_start():
     expected = (np.full((test_data.energy_bins,),
                         integration_val) /
                 test_data.livetime)
-    np.testing.assert_almost_equal(classifier.storage.iloc[0],
+    np.testing.assert_almost_equal(classifier.storage[0, 1:],
                                    expected,
                                    decimal=2)
     np.testing.assert_equal(len(classifier.storage), num_results-2)
@@ -201,7 +202,7 @@ def test_stop():
     expected = (np.full((test_data.energy_bins,),
                         integration_val) /
                 test_data.livetime)
-    np.testing.assert_almost_equal(classifier.storage.iloc[-1],
+    np.testing.assert_almost_equal(classifier.storage[-1, 1:],
                                    expected,
                                    decimal=2)
     np.testing.assert_equal(len(classifier.storage), periods-1)


### PR DESCRIPTION
This PR introducing an append feature to RadClass write-to-file methods and addresses several bug-fixes:

- `RadClass`, `H0`, and `BackgroundEstimator` now use `np.savetxt()` to write-to-file (this feature for `BackgroundEstimator` was included in #14). This removes `pandas` dependency on all parts of `RadClass`, now exclusively relying on `numpy` for array processing. Theoretically, this should improve speed without a lack of precision when processing large amounts of data and saving it to CSV. The iteration of `self.storage` as a `dict()` in `RadClass` was kept to utilize its lightweight "appending."
- Write-to-file now works when appending (except for `BackgroundEstimator`). This allows a user to loop over a data file in smaller chunks, while still writing successive spectra or hypothesis tests to file for later analyses.
- #27 is implicitly addressed in the changes to write-to-file discussed above. The for-loop no longer exists, if `self.triggers` is empty, it will still have a shape, and the result of `np.arange()` will be an empty array (and thus an empty header).
- #26 is addressed here. Initializing start and stop indices now uses a combination of `np.abs` (to find the absolute distance, and therefore nearest timestamp) and `np.argmin` (to find the minimum index) instead of `np.where` which can throw an error if no index is found. This is inspired from [here](https://www.kite.com/python/answers/how-to-find-the-numpy-array-element-closest-to-a-given-value-in-python).