### PR TITLE
Converting file writes from CSV to HDF5

### DIFF
--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -1,4 +1,5 @@
 import numpy as np
+import h5py
 import time
 import logging
 import progressbar
@@ -259,14 +260,32 @@ class RadClass:
         Write results to file using numpy.savetxt() method.
         filename should include the file extension.
         '''
-        with open(filename, 'a') as f:
-            header = ''
+        with h5py.File(filename+'.h5', 'a') as f:
+            keys = ['timestamps', 'spectra']
             # build/include header if file is new
-            if f.tell() == 0:
-                header = np.append(['timestamp'],
-                                   np.arange(len(self.cache[0])).astype(str))
-                header = ', '.join(col for col in header)
-            np.savetxt(fname=f,
-                       X=self.storage,
-                       delimiter=',',
-                       header=header)
+            if len(f.keys()) == 0:
+                # only chunked datasets can be resized,
+                #  so chunks must be initialized
+                f.create_dataset(keys[0],
+                                 self.storage[:, 0].shape,
+                                 data=self.storage[:, 0],
+                                 maxshape=(None,),
+                                 chunks=self.storage[:, 0].shape,
+                                 dtype='float64')
+                f.create_dataset(keys[1],
+                                 self.storage[:, 1:].shape,
+                                 data=self.storage[:, 1:],
+                                 maxshape=(None, 1000),
+                                 chunks=self.storage[:, 1:].shape,
+                                 dtype='float64')
+            else:
+                dset1 = f[keys[0]]
+                dset2 = f[keys[1]]
+
+                dset1.resize(dset1.shape[0]+self.storage[:, 0].shape[0],
+                             axis=0)
+                dset2.resize(dset2.shape[0]+self.storage[:, 1:].shape[0],
+                             axis=0)
+
+                dset1[-self.storage[:, 0].shape[0]:] = self.storage[:, 0]
+                dset2[-self.storage[:, 1:].shape[0]:] = self.storage[:, 1:]

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -257,8 +257,8 @@ class RadClass:
 
     def write(self, filename):
         '''
-        Write results to file using numpy.savetxt() method.
-        filename should include the file extension.
+        Write results to file using h5py, similar to MINOS file structure.
+        filename should not include the file extension.
         '''
         with h5py.File(filename+'.h5', 'a') as f:
             keys = ['timestamps', 'spectra']

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -1,4 +1,5 @@
 import numpy as np
+import h5py
 import pytest
 import os
 from datetime import datetime, timedelta
@@ -132,7 +133,7 @@ def test_stride():
 def test_write():
     stride = 60
     integration = 60
-    filename = 'test_results.csv'
+    filename = 'test_results'
 
     # run handler script
     classifier = RadClass(stride, integration, test_data.datapath,
@@ -147,10 +148,11 @@ def test_write():
                 test_data.livetime)
     # results array is only 1D because only one entry is expected
     # for test_data.timesteps
-    results = np.loadtxt(filename, delimiter=',')[1:]
-    np.testing.assert_almost_equal(results, expected, decimal=2)
+    keys = ['timestamps', 'spectra']
+    results = h5py.File(filename+'.h5', 'r')
+    np.testing.assert_almost_equal(results[keys[1]][0], expected, decimal=2)
 
-    os.remove(filename)
+    os.remove(filename+'.h5')
 
 
 def test_start():

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -143,15 +143,22 @@ def test_write():
 
     # the resulting 1-hour observation should be:
     #   counts * integration / live-time
-    expected = (np.full((test_data.energy_bins,),
+    exp_spec = (np.full((test_data.energy_bins,),
                         integration*(integration-1)/2) /
                 test_data.livetime)
-    # results array is only 1D because only one entry is expected
-    # for test_data.timesteps
+    # expect a 1D timestamps vector (shape: tuple) determined by integration
+    exp_time_shape = (test_data.timesteps // integration,)
+    # [::integration] only selects the beginning of each integration window
+    # [:exp_time_shape[0]] cuts off for whole integration windows
+    exp_timestamps = timestamps[::integration][:exp_time_shape[0]]
+
     keys = ['timestamps', 'spectra']
     results = h5py.File(filename+'.h5', 'r')
-    np.testing.assert_almost_equal(results[keys[1]][0], expected, decimal=2)
+    np.testing.assert_almost_equal(results[keys[1]][0], exp_spec, decimal=2)
+    np.testing.assert_equal(results[keys[0]].shape, exp_time_shape)
+    np.testing.assert_equal(results[keys[0]], exp_timestamps)
 
+    # test appending
     shape = results[keys[1]].shape
     # close readable file
     results.close()

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -152,6 +152,17 @@ def test_write():
     results = h5py.File(filename+'.h5', 'r')
     np.testing.assert_almost_equal(results[keys[1]][0], expected, decimal=2)
 
+    shape = results[keys[1]].shape
+    # close readable file
+    results.close()
+
+    # should append to written file
+    classifier.write(filename)
+    results = h5py.File(filename+'.h5', 'r')
+    # we expect the file to have twice as many lines
+    # since it was appended with the same information
+    np.testing.assert_equal(results[keys[1]].shape[0], 2*shape[0])
+
     os.remove(filename+'.h5')
 
 


### PR DESCRIPTION
Closes #30. I am considering the benefit of unifying the file structure used in analysis by changing CSV file writes in `RadClass` to HDF5 using h5py. This maintains file structures to similar formatting from MINOS. As an example, here is the change made to `RadClass.RadClass`.