### PR TITLE
Storing pval as np.log10(pval) and upgrading Scipy

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/RadClass/H0.py
+++ b/RadClass/H0.py
@@ -68,8 +68,13 @@ class H0:
             self.x2 = data
             n = self.x1 + self.x2
             p = 0.5
-            pval = stats.binomtest(int(self.x1), int(n), p,
-                                   alternative='two-sided').pvalue
+            # scipy.stats.binomtest will fail if n (# of trials)
+            # is less than 1 (possible for low count-rate integration times)
+            if int(n) < 1:
+                pval = 1.0
+            else:
+                pval = stats.binomtest(int(self.x1), int(n), p,
+                                       alternative='two-sided').pvalue
 
             # only save instances with rejected null hypotheses
             if pval <= self.significance:
@@ -101,8 +106,14 @@ class H0:
             nvec = self.x1 + self.x2
             p = 0.5
             for i, (x1, n) in enumerate(zip(self.x1, nvec)):
-                pval = stats.binomtest(int(x1), int(n), p,
-                                       alternative='two-sided').pvalue
+                # scipy.stats.binomtest will fail if n (# of trials)
+                # is less than 1 (possible for high-energy bins)
+                if int(n) < 1:
+                    pval = 1.0
+                else:
+                    pval = stats.binomtest(int(x1), int(n), p,
+                                           alternative='two-sided').pvalue
+                    
                 if pval <= self.significance:
                     rejections[i] = pval
             if np.sum(rejections) != len(rejections):

--- a/RadClass/H0.py
+++ b/RadClass/H0.py
@@ -104,8 +104,6 @@ class H0:
             self.x2 = data
             rejections = np.ones_like(data)
             nvec = self.x1 + self.x2
-            print('x1',self.x1)
-            print('x2',self.x2)
             p = 0.5
             for i, (x1, n) in enumerate(zip(self.x1, nvec)):
                 # scipy.stats.binomtest will fail if n (# of trials)
@@ -118,7 +116,6 @@ class H0:
 
                 if pval <= self.significance:
                     rejections[i] = pval
-            print(rejections)
             if np.sum(rejections) != len(rejections):
                 self.triggers = np.append(self.triggers,
                                           [np.insert(np.log10(rejections),

--- a/RadClass/H0.py
+++ b/RadClass/H0.py
@@ -65,10 +65,12 @@ class H0:
         if int(n) < 1:
             lpval = 0.0
         else:
-            lpval = np.log10(stats.binomtest(int(x1), int(n), p,
-                                             alternative='two-sided').pvalue)
-            if np.isinf(lpval):
+            pval = stats.binomtest(int(x1), int(n), p,
+                                   alternative='two-sided').pvalue
+            if pval == 0.0:
                 lpval = min_lpval
+            else:
+                lpval = np.log10(pval)
         return lpval
 
     def run_gross(self, data, timestamp):

--- a/RadClass/H0.py
+++ b/RadClass/H0.py
@@ -123,9 +123,6 @@ class H0:
             nvec = self.x1 + self.x2
             p = 0.5
             for i, (x1, n) in enumerate(zip(self.x1, nvec)):
-                print(type(x1))
-                print(type(n))
-                print(type(p))
                 lpval = self.binom(x1, n, p)
 
                 if lpval <= self.log_significance:

--- a/RadClass/H0.py
+++ b/RadClass/H0.py
@@ -15,7 +15,7 @@ class H0:
 
     For information on testing regime, see doi: 10.2307/2332612.
     For information on scipy's binomial test, see:
-    docs.scipy.org/doc/scipy/reference/generated/scipy.stats.binom_test.html
+    docs.scipy.org/doc/scipy/reference/generated/scipy.stats.binomtest.html
 
     Attributes:
     significance: Significance level for hypothesis test. If the resulting
@@ -29,6 +29,12 @@ class H0:
         rejected null hypotheses per the inputted significance level.
     trigger_times: The timestamp (in Unix epoch timestamp) for rejected null
         hypothesis via triggers.
+
+    Returns:
+    pvals: Maximum possible value is 1.0. pvals associated with rejected null
+        hypotheses (pval <= significance) are stored as log_10(pval).
+        Therefore, maximum possible -stored- value is 0.0. This avoids
+        float rounding for extremely small pvals.
     '''
 
     def __init__(self, significance=0.05, gross=True, energy_bins=1000):
@@ -65,10 +71,10 @@ class H0:
             pval = stats.binomtest(int(self.x1), int(n), p,
                                    alternative='two-sided').pvalue
 
-            # only save instances with rejected null hypothesesf
+            # only save instances with rejected null hypotheses
             if pval <= self.significance:
                 self.triggers = np.append(self.triggers,
-                                          [[self.x1_timestamp, pval,
+                                          [[self.x1_timestamp, np.log10(pval),
                                            self.x1, self.x2]],
                                           axis=0)
 
@@ -101,7 +107,7 @@ class H0:
                     rejections[i] = pval
             if np.sum(rejections) != len(rejections):
                 self.triggers = np.append(self.triggers,
-                                          [np.insert(rejections,
+                                          [np.insert(np.log10(rejections),
                                            0, self.x1_timestamp)],
                                           axis=0)
 

--- a/RadClass/H0.py
+++ b/RadClass/H0.py
@@ -104,6 +104,8 @@ class H0:
             self.x2 = data
             rejections = np.ones_like(data)
             nvec = self.x1 + self.x2
+            print('x1',self.x1)
+            print('x2',self.x2)
             p = 0.5
             for i, (x1, n) in enumerate(zip(self.x1, nvec)):
                 # scipy.stats.binomtest will fail if n (# of trials)
@@ -113,9 +115,10 @@ class H0:
                 else:
                     pval = stats.binomtest(int(x1), int(n), p,
                                            alternative='two-sided').pvalue
-                    
+
                 if pval <= self.significance:
                     rejections[i] = pval
+            print(rejections)
             if np.sum(rejections) != len(rejections):
                 self.triggers = np.append(self.triggers,
                                           [np.insert(np.log10(rejections),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 h5py
 progressbar2
-scipy
+scipy>=1.7.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='RadClass',
-      version='0.1.0',
+      version='0.1.1',
       description='Semi-Supervised Machine Learning for Radiation Signature Identification',
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/tests/test_H0.py
+++ b/tests/test_H0.py
@@ -38,7 +38,7 @@ def test_init():
                   gross=gross,
                   energy_bins=energy_bins)
 
-    np.testing.assert_equal(analysis.significance, significance)
+    np.testing.assert_equal(analysis.log_significance, np.log10(significance))
     np.testing.assert_equal(analysis.gross, gross)
     np.testing.assert_equal(analysis.triggers.shape, (0, energy_bins+1))
 
@@ -171,3 +171,5 @@ def test_zero_counts_channel():
     np.testing.assert_equal(obs_ts, 1)
     # only the first channel will have failed
     np.testing.assert_equal(np.count_nonzero(obs_pvals), 1)
+    # check that the first channel alone is rejected
+    np.testing.assert_equal(np.sum(obs_pvals), obs_pvals[0])

--- a/tests/test_H0.py
+++ b/tests/test_H0.py
@@ -131,6 +131,7 @@ def test_write_channel():
 
 
 def test_zero_counts_gross():
+    # accept all pvals
     significance = 1.0
     energy_bins = 10
 
@@ -150,6 +151,7 @@ def test_zero_counts_gross():
 
 
 def test_zero_counts_channel():
+    # accept all pvals
     significance = 1.0
     energy_bins = 10
 

--- a/tests/test_H0.py
+++ b/tests/test_H0.py
@@ -128,3 +128,44 @@ def test_write_channel():
     np.testing.assert_equal(obs, exp)
 
     os.remove(filename)
+
+
+def test_zero_counts_gross():
+    significance = 1.0
+    energy_bins = 10
+
+    analysis = H0(significance=significance,
+                  gross=True,
+                  energy_bins=energy_bins)
+
+    spectrum1 = np.zeros((10,))
+    spectrum2 = np.zeros((10,))
+    # run twice for initialization
+    analysis.run_gross(spectrum1, 1)
+    analysis.run_gross(spectrum2, 2)
+
+    obs = analysis.triggers
+    exp = np.array([[1.0, 0.0, 0.0, 0.0]])
+    np.testing.assert_equal(obs, exp)
+
+
+def test_zero_counts_channel():
+    significance = 1.0
+    energy_bins = 10
+
+    analysis = H0(significance=significance,
+                  gross=False,
+                  energy_bins=energy_bins)
+
+    spectrum1 = np.zeros((10,))
+    spectrum2 = np.zeros((10,))
+    spectrum2[0] = 100.0
+    # run twice for initialization
+    analysis.run_channels(spectrum1, 1)
+    analysis.run_channels(spectrum2, 2)
+
+    obs_pvals = analysis.triggers[0][1:]
+    obs_ts = analysis.triggers[0][0]
+    np.testing.assert_equal(obs_ts, 1)
+    # only the first channel will have failed
+    np.testing.assert_equal(np.count_nonzero(obs_pvals), 1)


### PR DESCRIPTION
Two features are added:

- `pvals` from the binomial test are now stored as `np.log10(pval)` to avoid float rounding for extremely small values. When channel-wise hypothesis testing is done (`run_channels`), channels in the spectral vector saved that are not rejected will be stored as `np.log10(1.0) = 0.0`. This addresses #31.
- The scipy version is specified in `requirements.txt` to be >= 1.7.0 because the binomial test version was changed from [`scipy.stats.binom_test`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.binom_test.html) to [`scipy.stats.binomtest`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.binomtest.html). This is because `binom_test` is deprecated and `binomtest` is recommended for current versions of scipy.