### PR TITLE
Resolving Timestamp IndexError Bug

### DIFF
--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -93,7 +93,12 @@ class RadClass:
 
         if self.start_time is not None:
             timestamp = self.processor.timestamps[self.processor.timestamps >=
-                                                  self.start_time][0]
+                                                  self.start_time]
+            # check if any timestamps were found
+            if timestamp.size == 0:
+                timestamp = self.processor.timestamps[0]
+            else:
+                timestamp = timestamp[0]
             self.start_i = max(np.searchsorted(self.processor.timestamps,
                                                timestamp,
                                                side='right')-1, 0)
@@ -102,7 +107,12 @@ class RadClass:
 
         if self.stop_time is not None:
             timestamp = self.processor.timestamps[self.processor.timestamps >=
-                                                  self.stop_time][0]
+                                                  self.stop_time]
+            # check if any timestamps were found
+            if timestamp.size == 0:
+                timestamp = self.processor.timestamps[-1]
+            else:
+                timestamp = timestamp[0]
             self.stop_i = np.searchsorted(self.processor.timestamps,
                                           timestamp,
                                           side='right')-1

--- a/tests/test_RadClass.py
+++ b/tests/test_RadClass.py
@@ -1,3 +1,4 @@
+from multiprocessing.sharedctypes import Value
 import numpy as np
 import pytest
 import os
@@ -207,3 +208,83 @@ def test_stop():
                                    expected,
                                    decimal=2)
     np.testing.assert_equal(len(classifier.storage), periods-1)
+
+
+def test_max_stop():
+    # arbitrary but results in less than # of timestamps
+    periods = 10
+
+    stride = int(test_data.timesteps/periods)
+    integration = int(test_data.timesteps/periods)
+    cache_size = 100
+    # stop after n-1 integration periods
+    # so n-1 results expected
+    stop_time = timestamps[-1]+1000.0
+
+    # run handler script
+    classifier = RadClass(stride, integration, test_data.datapath,
+                          test_data.filename, store_data=True,
+                          cache_size=cache_size, stop_time=stop_time)
+    classifier.run_all()
+
+    integration_val = (((integration*(periods-1)) *
+                        (integration*(periods-1)-1)/2) -
+                       ((integration*(periods-2)) *
+                        (integration*(periods-2)-1)/2))
+    expected = (np.full((test_data.energy_bins,),
+                        integration_val) /
+                test_data.livetime)
+    np.testing.assert_almost_equal(classifier.storage[-1, 1:],
+                                   expected,
+                                   decimal=2)
+    np.testing.assert_equal(len(classifier.storage), periods-1)
+
+
+def test_bad_start_stop():
+    '''
+    Checks if start_time > stop_time
+    '''
+    stride = int(test_data.timesteps/10)
+    integration = int(test_data.timesteps/10)
+
+    start_time = timestamps[1]
+    stop_time = timestamps[0]
+
+    # run handler script
+    classifier = RadClass(stride, integration, test_data.datapath,
+                          test_data.filename, start_time=start_time,
+                          stop_time=stop_time)
+    with pytest.raises(ValueError):
+        classifier.queue_file()
+
+
+def test_bad_start():
+    '''
+    Checks if start_time > last timestamp
+    '''
+    stride = int(test_data.timesteps/10)
+    integration = int(test_data.timesteps/10)
+
+    start_time = timestamps[-1] + 1000.0
+
+    # run handler script
+    classifier = RadClass(stride, integration, test_data.datapath,
+                          test_data.filename, start_time=start_time)
+    with pytest.raises(ValueError):
+        classifier.queue_file()
+
+
+def test_bad_stop():
+    '''
+    Checks if stop_time < first timestamp
+    '''
+    stride = int(test_data.timesteps/10)
+    integration = int(test_data.timesteps/10)
+
+    stop_time = timestamps[0] - 1000.0
+
+    # run handler script
+    classifier = RadClass(stride, integration, test_data.datapath,
+                          test_data.filename, stop_time=stop_time)
+    with pytest.raises(ValueError):
+        classifier.queue_file()


### PR DESCRIPTION
I'm proposing a few additional checks for user inputted `start_time` and `stop_time` edge cases. Addresses #35.

- `ValueErrors` will be raised for inputs that will not work with data processing (e.g. start_time > max timestamp, start_time > stop_time, stop_time < min timestamp)