### PR TITLE
[RadClass.RadClass] Calculating Difference Spectra

### DIFF
--- a/RadClass/DiffSpectra.py
+++ b/RadClass/DiffSpectra.py
@@ -16,10 +16,14 @@ class DiffSpectra:
         self.stride = stride
 
     def run(self, data):
+        # initializing spectra, with bckg to be subtracted below
         self.diff_spectra = data[self.stride:].copy()
+        # compute all integrated count-rates
         sums = np.sum(data[:, 1:], axis=1)
         for i in range(self.diff_spectra.shape[0]):
+            # select the smallest spectrum from a window self.stride long
             bckg_spectrum = data[np.argmin(sums[i:i+self.stride])+i]
+            # subtract background from stored spectrum
             self.diff_spectra[i, 1:] -= bckg_spectrum[1:]
 
     def write(self, filename):

--- a/RadClass/DiffSpectra.py
+++ b/RadClass/DiffSpectra.py
@@ -17,18 +17,16 @@ class DiffSpectra:
 
     def run(self, data):
         # index all windows of length self.diff_stride into a tmp array
-        windows = [data[i-self.stride:i] for i in range(self.stride-1, data.shape[0])]
-        # filter out any windows without enough bckg samples
-        # i.e. beginning of spectra w/ idx < self.diff_stride
-        windows = [x for x in windows if x.shape[0] == self.stride]
+        windows = [data[i-self.stride:i] for i in range(self.stride, data.shape[0])]
         # save the smallest (by gross counts) spectra
         # for each background window (skipping timestamp in first col)
         bckg_spectra = [x[np.argmin(np.sum(x[:, 1:], axis=1))] for x in windows]
 
         # skipping timestamp in first col, calculate difference spectra
-        self.diff_spectra = data[self.stride:, 1:] - np.asarray(bckg_spectra[:, 1:])
-        # save final data with timestamps
-        self.diff_spectra = np.c_[bckg_spectra[:, 0], bckg_spectra]
+        # for each spectrum with the bckg_spectra for the window prior to it
+        self.diff_spectra = data[self.stride:, 1:] - np.asarray(bckg_spectra)[:, 1:]
+        # save final data with timestamps from original data
+        self.diff_spectra = np.c_[data[self.stride:, 0], self.diff_spectra]
 
     def write(self, filename):
         '''

--- a/RadClass/DiffSpectra.py
+++ b/RadClass/DiffSpectra.py
@@ -18,12 +18,21 @@ class DiffSpectra:
     def run(self, data):
         # initializing spectra, with bckg to be subtracted below
         self.diff_spectra = data[self.stride:].copy()
-        # compute all integrated count-rates
+        # compute the gross integrated count-rate for every
+        # row/spectrum in the dataset
         sums = np.sum(data[:, 1:], axis=1)
+        # loop over every index in the difference spectra to be calculated
+        # that is, from self.stride to the end of the dataset
+        # (since those are the spectra with the requisite window
+        # of length self.stride before it)
         for i in range(self.diff_spectra.shape[0]):
-            # select the smallest spectrum from a window self.stride long
+            # from a window of sums (i.e. gross integrated count-rates)
+            # of length self.stride find the minimum
+            # select the smallest spectrum as bckg_spectrum
+            # sums includes all data [:] but bckg_spectrum is computed
+            # for [self.stride:], so indexing data is offset by i
             bckg_spectrum = data[np.argmin(sums[i:i+self.stride])+i]
-            # subtract background from stored spectrum
+            # subtract background from stored spectrum for the appropriate row
             self.diff_spectra[i, 1:] -= bckg_spectrum[1:]
 
     def write(self, filename):

--- a/RadClass/DiffSpectra.py
+++ b/RadClass/DiffSpectra.py
@@ -16,17 +16,11 @@ class DiffSpectra:
         self.stride = stride
 
     def run(self, data):
-        # index all windows of length self.diff_stride into a tmp array
-        windows = [data[i-self.stride:i] for i in range(self.stride, data.shape[0])]
-        # save the smallest (by gross counts) spectra
-        # for each background window (skipping timestamp in first col)
-        bckg_spectra = [x[np.argmin(np.sum(x[:, 1:], axis=1))] for x in windows]
-
-        # skipping timestamp in first col, calculate difference spectra
-        # for each spectrum with the bckg_spectra for the window prior to it
-        self.diff_spectra = data[self.stride:, 1:] - np.asarray(bckg_spectra)[:, 1:]
-        # save final data with timestamps from original data
-        self.diff_spectra = np.c_[data[self.stride:, 0], self.diff_spectra]
+        self.diff_spectra = data[self.stride:].copy()
+        sums = np.sum(data[:, 1:], axis=1)
+        for i in range(self.diff_spectra.shape[0]):
+            bckg_spectrum = data[np.argmin(sums[i:i+self.stride])+i]
+            self.diff_spectra[i, 1:] -= bckg_spectrum[1:]
 
     def write(self, filename):
         '''

--- a/RadClass/DiffSpectra.py
+++ b/RadClass/DiffSpectra.py
@@ -23,9 +23,26 @@ class DiffSpectra:
         windows = [x for x in windows if x.shape[0] == self.stride]
         # save the smallest (by gross counts) spectra
         # for each background window (skipping timestamp in first col)
-        bckg_spectra = [x[np.argmin(np.sum(x[:,1:], axis=1))] for x in windows]
+        bckg_spectra = [x[np.argmin(np.sum(x[:, 1:], axis=1))] for x in windows]
 
         # skipping timestamp in first col, calculate difference spectra
-        self.diff_spectra = data[self.stride:,1:] - np.asarray(bckg_spectra[:,1:])
+        self.diff_spectra = data[self.stride:, 1:] - np.asarray(bckg_spectra[:, 1:])
         # save final data with timestamps
-        self.diff_spectra = np.c_[bckg_spectra[:,0], bckg_spectra]
+        self.diff_spectra = np.c_[bckg_spectra[:, 0], bckg_spectra]
+
+    def write(self, filename):
+        '''
+        Write results to file using numpy.savetxt() method.
+        filename should include the file extension.
+        '''
+        with open(filename, 'a') as f:
+            header = ''
+            # build/include header if file is new
+            if f.tell() == 0:
+                header = np.append(['timestamp'],
+                                   np.arange(len(self.diff_spectra[0])).astype(str))
+                header = ', '.join(col for col in header)
+            np.savetxt(fname=f,
+                       X=self.diff_spectra,
+                       delimiter=',',
+                       header=header)

--- a/RadClass/DiffSpectra.py
+++ b/RadClass/DiffSpectra.py
@@ -17,7 +17,7 @@ class DiffSpectra:
 
     def run(self, data):
         # index all windows of length self.diff_stride into a tmp array
-        windows = [data[i-self.stride:self.stride] for i in range(self.stride-1, data.shape[0])]
+        windows = [data[i-self.stride:i] for i in range(self.stride-1, data.shape[0])]
         # filter out any windows without enough bckg samples
         # i.e. beginning of spectra w/ idx < self.diff_stride
         windows = [x for x in windows if x.shape[0] == self.stride]

--- a/RadClass/DiffSpectra.py
+++ b/RadClass/DiffSpectra.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+
+class DiffSpectra:
+    '''
+    Estimates a minimum background spectrum for each
+    timestamp/spectrum and saves a difference spectrum
+    between the two.
+
+    Attributes:
+    stride: The number of timestamps prior to the current
+        spectrum for finding the minimum background
+    '''
+
+    def __init__(self, stride=10):
+        self.stride = stride
+
+    def run(self, data):
+        # index all windows of length self.diff_stride into a tmp array
+        windows = [data[i-self.stride:self.stride] for i in range(self.stride-1, data.shape[0])]
+        # filter out any windows without enough bckg samples
+        # i.e. beginning of spectra w/ idx < self.diff_stride
+        windows = [x for x in windows if x.shape[0] == self.stride]
+        # save the smallest (by gross counts) spectra
+        # for each background window (skipping timestamp in first col)
+        bckg_spectra = [x[np.argmin(np.sum(x[:,1:], axis=1))] for x in windows]
+
+        # skipping timestamp in first col, calculate difference spectra
+        self.diff_spectra = data[self.stride:,1:] - np.asarray(bckg_spectra[:,1:])
+        # save final data with timestamps
+        self.diff_spectra = np.c_[bckg_spectra[:,0], bckg_spectra]

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -48,8 +48,8 @@ class RadClass:
     '''
 
     def __init__(self, stride, integration, datapath, filename, analysis=None,
-                 post_analysis=None, store_data=True, diff=False,
-                 cache_size=None, start_time=None, stop_time=None,
+                 post_analysis=None, store_data=True, cache_size=None,
+                 start_time=None, stop_time=None,
                  labels={'live': '2x4x16LiveTimes',
                          'timestamps': '2x4x16Times',
                          'spectra': '2x4x16Spectra'}):
@@ -58,8 +58,6 @@ class RadClass:
         self.datapath = datapath
         self.filename = filename
         self.store_data = store_data
-        self.diff = diff
-        self.diff_stride = integration / 6
 
         if cache_size is None:
             self.cache_size = self.integration
@@ -277,16 +275,3 @@ class RadClass:
                        X=self.storage,
                        delimiter=',',
                        header=header)
-
-        if self.diff:
-            with open('diff-'+filename, 'a') as f:
-                header = ''
-                # build/include header if file is new
-                if f.tell() == 0:
-                    header = np.append(['timestamp'],
-                                    np.arange(len(self.cache[0])).astype(str))
-                    header = ', '.join(col for col in header)
-                np.savetxt(fname=f,
-                        X=self.diff_spectra,
-                        delimiter=',',
-                        header=header)

--- a/RadClass/RadClass.py
+++ b/RadClass/RadClass.py
@@ -11,8 +11,7 @@ class RadClass:
     Bulk handler class. Contains most functions needed for processing data
         stream files and pass along to an analysis object.
 
-    Attributes:
-    running: indicates whether the end of a file has been reached and thus end.
+    Inputs:
     stride: The number of seconds (which equals the number of indexes
         to advance after analyzing an integration interval. e.g. if
         stride = 3, then the next integration period will setp 3 seconds ahead.
@@ -26,11 +25,6 @@ class RadClass:
     filename: The filename for the data to be analyzed.
     TODO: Make node and filename -lists- so that multiple nodes and files
         can be processed by the same object.
-    store_data: boolean; if true, save the results to a CSV file.
-    cache_size: Optional parameter to reduce file I/O and therefore
-        increase performance. Indexes a larger selection of rows to analyze.
-        cache_size -must- be greater than integration above.
-        If not provided (None), cache_size is ignored (equals integration).
     start_time: Unix epoch timestamp, in units of seconds. All data in filename
         at and after this point will be analyzed. Useful for processing only
         a portion of a data file. Default: None, ignored.
@@ -41,15 +35,30 @@ class RadClass:
     time.mktime(datetime.datetime.strptime(x, "%m/%d/%Y %H:%M:%S").timetuple())
     Where "%m/%d/%Y %H:%M:%S" is the string format (see datetime docs).
     Requires time and datetime modules
+    store_data: boolean; if true, save the resulting data to a numpy array.
+        This array can then be written using RadClass.write(). This must be
+        True for a post_analysis object to run.
+    analysis: AnalysisParameters object (e.g. H0 or BackgroundEstimator) that
+        will run iteratively as RadClass processes data. That is, for each
+        sample, that processed data slice will be passed to the analysis object
+        using its analysis.run() method.
+    post_analysis: AnalysisParameters object (e.g. DiffSpectra) that runs with
+        all data after it has been analyzed by RadClass. That is, all data
+        rows/samples will be analyzed simultaneously using this object's
+        post_analysis.run() method.
+    cache_size: Optional parameter to reduce file I/O and therefore
+        increase performance. Indexes a larger selection of rows to analyze.
+        cache_size -must- be greater than integration above.
+        If not provided (None), cache_size is ignored (equals integration).
     labels: list of dataset name labels in this order:
         [ live_label: live dataset name in HDF5 file,
           timestamps_label: timestamps dataset name in HDF5 file,
           spectra_label: spectra dataset name in HDF5 file ]
     '''
 
-    def __init__(self, stride, integration, datapath, filename, analysis=None,
-                 post_analysis=None, store_data=True, cache_size=None,
-                 start_time=None, stop_time=None,
+    def __init__(self, stride, integration, datapath, filename, start_time=None,
+                 stop_time=None, analysis=None, post_analysis=None,
+                 store_data=True, cache_size=None,
                  labels={'live': '2x4x16LiveTimes',
                          'timestamps': '2x4x16Times',
                          'spectra': '2x4x16Spectra'}):

--- a/tests/test_DiffSpectra.py
+++ b/tests/test_DiffSpectra.py
@@ -64,3 +64,28 @@ def test_difference():
     # after the first diff_stride spectra)
     exp_ts = classifier.storage[diff_stride:, 0]
     np.testing.assert_equal(diff_spectra[:, 0], exp_ts)
+
+
+def test_write():
+    stride = 10
+    integration = 10
+    filename = 'DiffSpectra_test.csv'
+
+    # run handler script with analysis parameter
+    # small stride since there are less data samples in test_data
+    diff_stride = 2
+    post_analysis = DiffSpectra(stride=diff_stride)
+    classifier = RadClass(stride, integration, test_data.datapath,
+                          test_data.filename, post_analysis=post_analysis,
+                          store_data=True)
+    classifier.run_all()
+    post_analysis.write(filename)
+
+    results = np.loadtxt(filename, delimiter=',')
+    # 1 extra columns are required for timestamp
+    # expected shape is only 1D because only 1 entry is expected
+    obs = results.shape
+    exp = (classifier.storage.shape[0] - diff_stride, test_data.energy_bins+1)
+    np.testing.assert_equal(obs, exp)
+
+    os.remove(filename)

--- a/tests/test_DiffSpectra.py
+++ b/tests/test_DiffSpectra.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+import os
+from datetime import datetime, timedelta
+
+from RadClass.RadClass import RadClass
+from RadClass.DiffSpectra import DiffSpectra
+import tests.test_data as test_data
+
+# initialize sample data
+start_date = datetime(2019, 2, 2)
+delta = timedelta(seconds=1)
+timestamps = np.arange(start_date,
+                       start_date + (test_data.timesteps * delta),
+                       delta).astype('datetime64[s]').astype('float64')
+
+live = np.full((len(timestamps),), test_data.livetime)
+spectra = np.arange(test_data.timesteps)
+spectra = np.full((test_data.energy_bins, spectra.shape[0]), spectra).T
+
+
+@pytest.fixture(scope="module", autouse=True)
+def init_test_file():
+    # create sample test file with above simulated data
+    yield test_data.create_file(live, timestamps, spectra)
+    os.remove(test_data.filename)
+
+
+def test_difference():
+    stride = 10
+    integration = 10
+
+    # run handler script with analysis parameter
+    post_analysis = DiffSpectra()
+    classifier = RadClass(stride, integration, test_data.datapath,
+                          test_data.filename, post_analysis=post_analysis,
+                          store_data=True)
+    classifier.run_all()
+
+    diff_spectra = post_analysis.diff_spectra
+    print(post_analysis.diff_spectra.shape)
+    print(diff_spectra)
+    exp = np.ones_like(diff_spectra)
+    np.testing.assert_equal(diff_spectra, exp)

--- a/tests/test_DiffSpectra.py
+++ b/tests/test_DiffSpectra.py
@@ -51,8 +51,13 @@ def test_difference():
     # in a window (because the spectra increase 1, 2, 3, 4, etc.)
     # therefore the diff spectra element values will always be
     # spectra[i] - spectra[i-diff_stride]
-    # (the algebra for n(n+1)/2 integrated intervals with some diff_stride
-    # is simplified below)
+    # the counts in a given window are defined analytically for
+    # the spectral structure in test_data as:
+    # n1 = integration + diff_stride * stride
+    # n2 = integration + (diff_stride - 1) * stride
+    # n3 = integration
+    # diff_value = (n1^2 + n1) - (n2^2 + n2) - (n3^2 + n3)
+    # (the algebra is simplified below)
     diff_value = (2*diff_stride*stride**2) - stride**2 - integration**2 \
         + (2*stride*integration) + stride - integration
     exp_spectra = np.full((exp_len, test_data.energy_bins),

--- a/tests/test_DiffSpectra.py
+++ b/tests/test_DiffSpectra.py
@@ -51,8 +51,9 @@ def test_difference():
     # in a window (because the spectra increase 1, 2, 3, 4, etc.)
     # therefore the diff spectra element values will always be
     # spectra[i] - spectra[i-diff_stride]
-    # (the algebra for n(n+1)/2 integrated intervals is simplified below)
-    diff_value = 3*stride**2 - integration**2 \
+    # (the algebra for n(n+1)/2 integrated intervals with some diff_stride
+    # is simplified below)
+    diff_value = (2*diff_stride*stride**2) - stride**2 - integration**2 \
         + (2*stride*integration) + stride - integration
     exp_spectra = np.full((exp_len, test_data.energy_bins),
                           diff_value/(2*test_data.livetime))

--- a/tests/test_DiffSpectra.py
+++ b/tests/test_DiffSpectra.py
@@ -40,14 +40,27 @@ def test_difference():
     classifier.run_all()
 
     diff_spectra = post_analysis.diff_spectra
+    # DiffSpectra length test:
+    # there should be one difference spectrum for each timestamp with
+    # diff_stride number of spectra before it
+    exp_len = classifier.storage.shape[0] - diff_stride
+    np.testing.assert_equal(diff_spectra.shape[0], exp_len)
+
+    # DiffSpectra value test:
     # for test_data, the minimum background will always be the first spectrum
     # in a window (because the spectra increase 1, 2, 3, 4, etc.)
     # therefore the diff spectra element values will always be
     # spectra[i] - spectra[i-diff_stride]
-    # the algebra for n(n+1)/2 integrated intervals is simplified below:
+    # (the algebra for n(n+1)/2 integrated intervals is simplified below)
     diff_value = 3*stride**2 - integration**2 \
         + (2*stride*integration) + stride - integration
-    exp_spectra = np.full((classifier.storage.shape[0]-diff_stride,
-                           test_data.energy_bins),
+    exp_spectra = np.full((exp_len, test_data.energy_bins),
                           diff_value/(2*test_data.livetime))
-    np.testing.assert_almost_equal(diff_spectra[:, 1:], exp_spectra)
+    np.testing.assert_almost_equal(diff_spectra[:, 1:], exp_spectra, decimal=2)
+
+    # DiffSpectra timestamp test:
+    # there should be one difference spectrum for each timestamp with
+    # diff_stride number of spectra before it (i.e. spectra for every timestamp
+    # after the first diff_stride spectra)
+    exp_ts = classifier.storage[diff_stride:, 0]
+    np.testing.assert_equal(diff_spectra[:, 0], exp_ts)


### PR DESCRIPTION
This PR addresses #32 by calculating and saving the difference between a timestamp's spectrum and the minimum gross count-rate spectrum from the previous `integration / 6` timestamps. A few thoughts:

- `integration / 6` was chosen so that the default 60 second integration results in a background stride of 10. i.e. 10 timestamps/minutes prior to the current timestamp will be used in estimating background.
- There is probably a more NumPy-thonic way of estimating background, considering this method constructs three lists with inline for-loops before converting to an array, but I was trying to respect the existing data structures (e.g. `self.storage`).
- **Most importantly:** should this even live in `RadClass.RadClass`? It may be more appropriate to calculate "difference spectra" in post-processing, like I currently do. This is possible if all the spectral data is saved (`store_data=True`). Then, these lines could be run in another script. This may be a good time to create some form of a `helper.py` script with functions useful for post-processing, but not appropriate for `RadClass` proper. Another example would be a wrapper script for quickly computing `n-component` PCAs for a given dataset.

- [x] This PR still needs new unit tests for computing difference spectra.